### PR TITLE
Fix critical bugs: race conditions, crashes, and broken state management

### DIFF
--- a/apps/ast/lib/js/j_s_parser.ex
+++ b/apps/ast/lib/js/j_s_parser.ex
@@ -3,14 +3,27 @@ defmodule JS.JSParser do
   Parser AST para JavaScript usando Node.js via Port
   """
 
+  @ast_app_root Path.expand("../..", __DIR__)
+
   def parse(javascript_code) do
-    port = Port.open({:spawn, "node js_parser.js" }, [:binary])
+    parser_path = Path.join(@ast_app_root, "js_parser.js")
+    port = Port.open(
+      {:spawn, "node #{parser_path}"},
+      [:binary, :exit_status, {:cd, @ast_app_root}]
+    )
     Port.command(port, javascript_code)
 
+    collect_port_data(port, "")
+  end
+
+  defp collect_port_data(port, acc) do
     receive do
-      {^port, {:data, result}} ->
-        Port.close(port)
-        Jason.decode(result)
+      {^port, {:data, data}} ->
+        collect_port_data(port, acc <> data)
+      {^port, {:exit_status, 0}} ->
+        Jason.decode(acc)
+      {^port, {:exit_status, status}} ->
+        {:error, {:exit_status, status}}
     after 5000 ->
       Port.close(port)
       {:error, :timeout}

--- a/apps/ast/lib/js/j_s_parser.ex
+++ b/apps/ast/lib/js/j_s_parser.ex
@@ -23,7 +23,7 @@ defmodule JS.JSParser do
       {^port, {:exit_status, 0}} ->
         Jason.decode(acc)
       {^port, {:exit_status, status}} ->
-        {:error, {:exit_status, status}}
+        {:error, {:exit_status, status}} 
     after 5000 ->
       Port.close(port)
       {:error, :timeout}

--- a/apps/kanban_domain/lib/kanban_vision_api/agent/simulations.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/agent/simulations.ex
@@ -21,74 +21,73 @@ defmodule KanbanVisionApi.Agent.Simulations do
 
   @spec start_link(KanbanVisionApi.Agent.Simulations.t) :: Agent.on_start()
   def start_link(default \\ KanbanVisionApi.Agent.Simulations.new) do
-    Agent.start_link(fn -> default end, name: String.to_atom(default.id))
+    Agent.start_link(fn -> default end)
   end
 
-  def get_all(id) do
-    Agent.get(id, fn state -> state.simulations_by_organization end)
+  def get_all(pid) do
+    Agent.get(pid, fn state -> state.simulations_by_organization end)
   end
 
   def add(pid, new_simulation = %KanbanVisionApi.Domain.Simulation{}) do
-    result = get_by_organization_id_and_simulation_name(
-      pid,
-      new_simulation.organization_id,
-      new_simulation.name
-    )
-
-    Agent.update(pid, fn state ->
-
-      map_of_simulations = Map.get(
-        state.simulations_by_organization,
-        new_simulation.organization_id, %{}
-      )
-
-      new_simulations_by_organization = Map.put_new(
-        map_of_simulations,
-        new_simulation.id, new_simulation
+    Agent.get_and_update(pid, fn state ->
+      result = internal_find_by_org_and_name(
+        state, new_simulation.organization_id, new_simulation.name
       )
 
       case result do
-        {:error, _} -> put_in(
-                         state.simulations_by_organization,
-                         Map.put(
-                           state.simulations_by_organization,
-                           new_simulation.organization_id, new_simulations_by_organization
-                         )
-                       )
-        {:ok, _} -> state
+        {:error, _} ->
+          map_of_simulations = Map.get(
+            state.simulations_by_organization,
+            new_simulation.organization_id, %{}
+          )
+
+          new_simulations_map = Map.put_new(
+            map_of_simulations,
+            new_simulation.id, new_simulation
+          )
+
+          new_state = put_in(
+            state.simulations_by_organization,
+            Map.put(
+              state.simulations_by_organization,
+              new_simulation.organization_id, new_simulations_map
+            )
+          )
+
+          {{:ok, new_simulation}, new_state}
+
+        {:ok, _} ->
+          {{:error,
+            """
+            Simulation with organization_id: #{new_simulation.organization_id}
+            name: #{new_simulation.name} already exist
+            """}, state}
       end
     end)
-
-    case result do
-      {:error, _} -> {:ok, new_simulation}
-      {:ok, _} -> {
-                    :error,
-                    """
-                    Simulation with organization_id: #{new_simulation.organization_id}
-                    name: #{new_simulation.name} already exist
-                    """
-                  }
-    end
   end
 
   def get_by_organization_id_and_simulation_name(pid, organization_id, simulation_name) do
-    result = get_by_organization_id(pid, organization_id)
+    Agent.get(pid, fn state ->
+      internal_find_by_org_and_name(state, organization_id, simulation_name)
+    end)
+  end
 
-    case result do
-      {:error, _} -> result
-      {:ok, map_of_simulations} ->
-        find_by_symulation_name(map_of_simulations, organization_id, simulation_name)
+  defp internal_find_by_org_and_name(state, organization_id, simulation_name) do
+    case Map.get(state.simulations_by_organization, organization_id) do
+      nil -> {:error, "Simulation with organization id: #{organization_id} not found"}
+      map_of_simulations ->
+        find_by_simulation_name(map_of_simulations, organization_id, simulation_name)
     end
   end
 
-  defp find_by_symulation_name(map_of_simulations, organization_id, simulation_name) do
+  defp find_by_simulation_name(map_of_simulations, organization_id, simulation_name) do
     case Map.values(map_of_simulations) do
       [] -> {:error, "Simulation with organization id: #{organization_id} not found"}
-      list_of_simulations -> find_by_symulation_name(list_of_simulations, simulation_name)
+      list_of_simulations -> find_by_simulation_name(list_of_simulations, simulation_name)
     end
   end
 
-  defp find_by_symulation_name(list_of_simulations, simulation_name) do
+  defp find_by_simulation_name(list_of_simulations, simulation_name) do
     case Enum.find(
            list_of_simulations,
            fn simulation -> simulation.name == simulation_name end
@@ -96,14 +95,5 @@ defmodule KanbanVisionApi.Agent.Simulations do
       nil -> {:error, "Simulation with name: #{simulation_name} not found"}
       simulation -> {:ok, simulation}
     end
-  end
-
-  defp get_by_organization_id(pid, organization_id) do
-    Agent.get(pid, fn state ->
-      case Map.get(state.simulations_by_organization, organization_id) do
-        nil -> {:error, "Simulation with organization id: #{organization_id} not found"}
-        map_of_simulations -> {:ok, map_of_simulations}
-      end
-    end)
   end
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/project.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/project.ex
@@ -10,9 +10,12 @@ defmodule KanbanVisionApi.Domain.Project do
                tasks: List.t(KanbanVisionApi.Domain.Task.t())
              }
 
-  def new(name) do
+  def new(name, order \\ 0, tasks \\ [], id \\ UUID.uuid4()) do
     %KanbanVisionApi.Domain.Project{
-      name: name
+      id: id,
+      name: name,
+      order: order,
+      tasks: tasks
     }
   end
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/simulation.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/simulation.ex
@@ -1,7 +1,7 @@
 defmodule KanbanVisionApi.Domain.Simulation do
   @moduledoc false
 
-  defstruct [:id, :audit, :name, :description, :organization_id, :board, :defualt_projects]
+  defstruct [:id, :audit, :name, :description, :organization_id, :board, :default_projects]
 
   @type t :: %KanbanVisionApi.Domain.Simulation{
                id: String.t(),
@@ -9,8 +9,8 @@ defmodule KanbanVisionApi.Domain.Simulation do
                name: String.t(),
                description: String.t(),
                organization_id: String.t(),
-               board: KanbanVisionApi.Domain.Board.t(),
-               defualt_projects: List.t(KanbanVisionApi.Domain.Project.t())
+               board: KanbanVisionApi.Domain.Board.t() | nil,
+               default_projects: List.t(KanbanVisionApi.Domain.Project.t())
              }
 
   def new(
@@ -29,7 +29,7 @@ defmodule KanbanVisionApi.Domain.Simulation do
       description: description,
       organization_id: organization_id,
       board: board,
-      defualt_projects: default_projects
+      default_projects: default_projects
     }
   end
 end

--- a/apps/kanban_domain/test/kanban_vision_api/agent/boards_test.exs
+++ b/apps/kanban_domain/test/kanban_vision_api/agent/boards_test.exs
@@ -24,6 +24,50 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
       template = {:error, "Boards by simulation_id: nada not found"}
       assert KanbanVisionApi.Agent.Boards.get_all_by_simulation_id(pid, "nada") == template
     end
+
+    @tag :domain_boards
+    test "should be able to add a new board", %{
+           actor_pid: pid
+         } = _context do
+
+      board = KanbanVisionApi.Domain.Board.new("Dev Board", "sim-123")
+      assert {:ok, ^board} = KanbanVisionApi.Agent.Boards.add(pid, board)
+      assert %{} = KanbanVisionApi.Agent.Boards.get_all(pid)
+    end
+
+    @tag :domain_boards
+    test "should not add a board with same name and simulation_id", %{
+           actor_pid: pid
+         } = _context do
+
+      board = KanbanVisionApi.Domain.Board.new("Dev Board", "sim-123")
+      assert {:ok, ^board} = KanbanVisionApi.Agent.Boards.add(pid, board)
+
+      duplicate = KanbanVisionApi.Domain.Board.new("Dev Board", "sim-123")
+      assert {:error, _msg} = KanbanVisionApi.Agent.Boards.add(pid, duplicate)
+    end
+  end
+
+  describe "When start the system with existing boards" do
+    setup [:prepare_context_with_boards]
+
+    @tag :domain_boards
+    test "should get boards by simulation_id", %{
+           actor_pid: pid,
+           board: board
+         } = _context do
+
+      assert {:ok, boards} = KanbanVisionApi.Agent.Boards.get_all_by_simulation_id(pid, board.simulation_id)
+      assert length(boards) == 1
+    end
+
+    @tag :domain_boards
+    test "should return error for unknown simulation_id", %{
+           actor_pid: pid
+         } = _context do
+
+      assert {:error, _msg} = KanbanVisionApi.Agent.Boards.get_all_by_simulation_id(pid, "unknown")
+    end
   end
 
   defp prepare_empty_context(_context) do
@@ -34,6 +78,17 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
       actor_pid: pid,
       boards: boards_domain,
       workflow: workflow_domain
+    ]
+  end
+
+  defp prepare_context_with_boards(_context) do
+    board = KanbanVisionApi.Domain.Board.new("Dev Board", "sim-123")
+    boards_domain = KanbanVisionApi.Agent.Boards.new(%{board.id => board})
+    {:ok, pid} = KanbanVisionApi.Agent.Boards.start_link(boards_domain)
+    [
+      actor_pid: pid,
+      boards: boards_domain,
+      board: board
     ]
   end
 end

--- a/apps/kanban_domain/test/kanban_vision_api/agent/boards_test.exs
+++ b/apps/kanban_domain/test/kanban_vision_api/agent/boards_test.exs
@@ -28,7 +28,7 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
 
   defp prepare_empty_context(_context) do
     boards_domain = KanbanVisionApi.Agent.Boards.new()
-    workflow_domain = KanbanVisionApi.Domain.Workflow.new("ExampleWorkflow")
+    workflow_domain = KanbanVisionApi.Domain.Workflow.new()
     {:ok, pid} = KanbanVisionApi.Agent.Boards.start_link(boards_domain)
     [
       actor_pid: pid,

--- a/apps/kanban_domain/test/kanban_vision_api/agent/simulations_test.exs
+++ b/apps/kanban_domain/test/kanban_vision_api/agent/simulations_test.exs
@@ -104,7 +104,7 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
 
   defp prepare_empty_context(_context) do
     simulations_domain = KanbanVisionApi.Agent.Simulations.new()
-    organization_domain = KanbanVisionApi.Agent.Organizations.new("ExampleOrg")
+    organization_domain = KanbanVisionApi.Domain.Organization.new("ExampleOrg")
     {:ok, pid} = KanbanVisionApi.Agent.Simulations.start_link(simulations_domain)
     [
       actor_pid: pid,
@@ -114,7 +114,7 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
   end
 
   defp prepare_context_with_data(_context) do
-    organization_domain = KanbanVisionApi.Agent.Organizations.new("ExampleOrg")
+    organization_domain = KanbanVisionApi.Domain.Organization.new("ExampleOrg")
     simulation_domain = KanbanVisionApi.Domain.Simulation.new(
       "ExampleSimulation",
       "ExampleSimulationDescription",

--- a/apps/usecase/lib/kanban_vision_api/usecase/organization.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organization.ex
@@ -1,11 +1,11 @@
 defmodule KanbanVisionApi.Usecase.Organization do
   @moduledoc false
 
-  @behaviour GenServer
+  use GenServer
 
   # Client
 
-  @spec start_link(list) :: GenServer.on_start()
+  @spec start_link(map) :: GenServer.on_start()
   def start_link(default \\ %{}) when is_map(default) do
     GenServer.start_link(__MODULE__, default)
   end

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulation.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulation.ex
@@ -1,11 +1,11 @@
 defmodule KanbanVisionApi.Usecase.Simulation do
   @moduledoc false
 
-  @behaviour GenServer
+  use GenServer
 
   # Client
 
-  @spec start_link(list) :: GenServer.on_start()
+  @spec start_link(map) :: GenServer.on_start()
   def start_link(default \\ %{}) when is_map(default) do
     GenServer.start_link(__MODULE__, default)
   end
@@ -32,6 +32,7 @@ defmodule KanbanVisionApi.Usecase.Simulation do
 
   @impl true
   def handle_call({:push, element}, _from, state) do
-    {:reply, {:ok, element}, state}
+    new_state = Map.put(state, element.id, element)
+    {:reply, {:ok, element}, new_state}
   end
 end


### PR DESCRIPTION
- Fix race conditions in all Agents using Agent.get_and_update for atomic ops
- Fix Enum.filter crash in boards.ex (tuple pattern on Map.values)
- Fix GenServer push not updating state in Simulation usecase
- Replace @behaviour GenServer with use GenServer for default callbacks
- Remove String.to_atom(UUID) to prevent atom table exhaustion
- Fix defualt_projects typo in Simulation domain struct
- Fix Project.new missing id/order/tasks generation
- Fix JSParser port path resolution and chunk accumulation
- Fix tests using wrong struct types and wrong function arguments