### PR TITLE
Refactor to Ports & Adapters with Command/Query DTOs

### DIFF
--- a/apps/kanban_domain/lib/kanban_vision_api/domain/ability.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/ability.ex
@@ -3,17 +3,17 @@ defmodule KanbanVisionApi.Domain.Ability do
 
   defstruct [:id, :audit, :name]
 
-  @type t :: %KanbanVisionApi.Domain.Ability {
-               id: String.t,
-               audit: KanbanVisionApi.Domain.Audit.t,
-               name: String.t,
-             }
+  @type t :: %KanbanVisionApi.Domain.Ability{
+          id: String.t(),
+          audit: KanbanVisionApi.Domain.Audit.t(),
+          name: String.t()
+        }
 
-  def new(name, id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new) do
+  def new(name, id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new()) do
     %KanbanVisionApi.Domain.Ability{
       id: id,
       audit: audit,
-      name: name,
+      name: name
     }
   end
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/audit.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/audit.ex
@@ -3,10 +3,10 @@ defmodule KanbanVisionApi.Domain.Audit do
 
   defstruct [:created, :updated]
 
-  @type t :: %KanbanVisionApi.Domain.Audit {
-               created: DateTime,
-               updated: DateTime
-             }
+  @type t :: %KanbanVisionApi.Domain.Audit{
+          created: DateTime,
+          updated: DateTime
+        }
 
   def new do
     %KanbanVisionApi.Domain.Audit{
@@ -14,5 +14,4 @@ defmodule KanbanVisionApi.Domain.Audit do
       updated: DateTime.utc_now()
     }
   end
-
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/board.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/board.ex
@@ -3,31 +3,32 @@ defmodule KanbanVisionApi.Domain.Board do
 
   defstruct [:id, :audit, :name, :simulation_id, :workflow, :workers]
 
-  @type t :: %KanbanVisionApi.Domain.Board {
-               id: String.t,
-               audit: KanbanVisionApi.Domain.Audit.t,
-               name: String.t,
-               simulation_id: String.t,
-               workflow: KanbanVisionApi.Domain.Workflow.t, 
-               workers: List.t
-             }
+  @type t :: %KanbanVisionApi.Domain.Board{
+          id: String.t(),
+          audit: KanbanVisionApi.Domain.Audit.t(),
+          name: String.t(),
+          simulation_id: String.t(),
+          workflow: KanbanVisionApi.Domain.Workflow.t(),
+          workers: List.t()
+        }
 
   def new(
         name \\ "Default",
         simulation_id \\ "Default Simulation ID",
-        workflow  \\ %KanbanVisionApi.Domain.Workflow{}, 
-        workers \\ %{}, 
-        id \\ UUID.uuid4(), 
-        audit \\ KanbanVisionApi.Domain.Audit.new
+        workflow \\ %KanbanVisionApi.Domain.Workflow{},
+        workers \\ %{},
+        id \\ UUID.uuid4(),
+        audit \\ KanbanVisionApi.Domain.Audit.new()
       ) do
     initial_state = %KanbanVisionApi.Domain.Board{
       id: id,
       audit: audit,
       name: name,
       simulation_id: simulation_id,
-      workflow: workflow, 
+      workflow: workflow,
       workers: workers
     }
+
     initial_state
   end
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/organization.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/organization.ex
@@ -3,14 +3,14 @@ defmodule KanbanVisionApi.Domain.Organization do
 
   defstruct [:id, :audit, :name, :tribes]
 
-  @type t :: %KanbanVisionApi.Domain.Organization {
-               id: String.t,
-               audit: KanbanVisionApi.Domain.Audit.t,
-               name: String.t,
-               tribes: List.t
-             }
+  @type t :: %KanbanVisionApi.Domain.Organization{
+          id: String.t(),
+          audit: KanbanVisionApi.Domain.Audit.t(),
+          name: String.t(),
+          tribes: List.t()
+        }
 
-  def new(name, tribes \\ [], id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new) do
+  def new(name, tribes \\ [], id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new()) do
     %KanbanVisionApi.Domain.Organization{
       id: id,
       audit: audit,

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/ports/board_repository.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/ports/board_repository.ex
@@ -1,0 +1,10 @@
+defmodule KanbanVisionApi.Domain.Ports.BoardRepository do
+  @moduledoc """
+  Port defining the contract for board persistence.
+  """
+
+  @callback get_all(pid :: pid()) :: map()
+  @callback add(pid :: pid(), board :: struct()) :: {:ok, struct()} | {:error, String.t()}
+  @callback get_all_by_simulation_id(pid :: pid(), simulation_id :: String.t()) ::
+              {:ok, list()} | {:error, String.t()}
+end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/ports/organization_repository.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/ports/organization_repository.ex
@@ -1,0 +1,11 @@
+defmodule KanbanVisionApi.Domain.Ports.OrganizationRepository do
+  @moduledoc """
+  Port defining the contract for organization persistence.
+  """
+
+  @callback get_all(pid :: pid()) :: map()
+  @callback get_by_id(pid :: pid(), id :: String.t()) :: {:ok, struct()} | {:error, String.t()}
+  @callback get_by_name(pid :: pid(), name :: String.t()) :: {:ok, list()} | {:error, String.t()}
+  @callback add(pid :: pid(), organization :: struct()) :: {:ok, struct()} | {:error, String.t()}
+  @callback delete(pid :: pid(), id :: String.t()) :: {:ok, struct()} | {:error, String.t()}
+end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/ports/simulation_repository.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/ports/simulation_repository.ex
@@ -1,0 +1,13 @@
+defmodule KanbanVisionApi.Domain.Ports.SimulationRepository do
+  @moduledoc """
+  Port defining the contract for simulation persistence.
+  """
+
+  @callback get_all(pid :: pid()) :: map()
+  @callback add(pid :: pid(), simulation :: struct()) :: {:ok, struct()} | {:error, String.t()}
+  @callback get_by_organization_id_and_simulation_name(
+              pid :: pid(),
+              org_id :: String.t(),
+              name :: String.t()
+            ) :: {:ok, struct()} | {:error, String.t()}
+end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/project.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/project.ex
@@ -1,18 +1,26 @@
 defmodule KanbanVisionApi.Domain.Project do
   @moduledoc false
 
-  defstruct [:id, :name, :order, :tasks]
+  defstruct [:id, :audit, :name, :order, :tasks]
 
   @type t :: %KanbanVisionApi.Domain.Project{
-               id: String.t(),
-               name: String.t(),
-               order: Integer.t(),
-               tasks: List.t(KanbanVisionApi.Domain.Task.t())
-             }
+          id: String.t(),
+          audit: KanbanVisionApi.Domain.Audit.t(),
+          name: String.t(),
+          order: Integer.t(),
+          tasks: List.t(KanbanVisionApi.Domain.Task.t())
+        }
 
-  def new(name, order \\ 0, tasks \\ [], id \\ UUID.uuid4()) do
+  def new(
+        name,
+        order \\ 0,
+        tasks \\ [],
+        id \\ UUID.uuid4(),
+        audit \\ KanbanVisionApi.Domain.Audit.new()
+      ) do
     %KanbanVisionApi.Domain.Project{
       id: id,
+      audit: audit,
       name: name,
       order: order,
       tasks: tasks

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/service_class.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/service_class.ex
@@ -3,18 +3,19 @@ defmodule KanbanVisionApi.Domain.ServiceClass do
 
   defstruct [:id, :audit, :name]
 
-  @type t :: %KanbanVisionApi.Domain.ServiceClass {
-               id: String.t,
-               audit: KanbanVisionApi.Domain.Audit.t,
-               name: String.t,
-             }
+  @type t :: %KanbanVisionApi.Domain.ServiceClass{
+          id: String.t(),
+          audit: KanbanVisionApi.Domain.Audit.t(),
+          name: String.t()
+        }
 
-  def new(name, id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new) do
+  def new(name, id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new()) do
     initial_state = %KanbanVisionApi.Domain.ServiceClass{
       id: id,
       audit: audit,
       name: name
     }
+
     initial_state
   end
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/simulation.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/simulation.ex
@@ -4,14 +4,14 @@ defmodule KanbanVisionApi.Domain.Simulation do
   defstruct [:id, :audit, :name, :description, :organization_id, :board, :default_projects]
 
   @type t :: %KanbanVisionApi.Domain.Simulation{
-               id: String.t(),
-               audit: KanbanVisionApi.Domain.Audit.t(),
-               name: String.t(),
-               description: String.t(),
-               organization_id: String.t(),
-               board: KanbanVisionApi.Domain.Board.t() | nil,
-               default_projects: List.t(KanbanVisionApi.Domain.Project.t())
-             }
+          id: String.t(),
+          audit: KanbanVisionApi.Domain.Audit.t(),
+          name: String.t(),
+          description: String.t(),
+          organization_id: String.t(),
+          board: KanbanVisionApi.Domain.Board.t() | nil,
+          default_projects: List.t(KanbanVisionApi.Domain.Project.t())
+        }
 
   def new(
         name,
@@ -20,7 +20,7 @@ defmodule KanbanVisionApi.Domain.Simulation do
         board \\ KanbanVisionApi.Domain.Board.new(),
         default_projects \\ [],
         id \\ UUID.uuid4(),
-        audit \\ KanbanVisionApi.Domain.Audit.new
+        audit \\ KanbanVisionApi.Domain.Audit.new()
       ) do
     %KanbanVisionApi.Domain.Simulation{
       id: id,

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/squad.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/squad.ex
@@ -3,20 +3,21 @@ defmodule KanbanVisionApi.Domain.Squad do
 
   defstruct [:id, :audit, :name, :workers]
 
-  @type t :: %KanbanVisionApi.Domain.Squad {
-               id: String.t,
-               audit: KanbanVisionApi.Domain.Audit.t,
-               name: String.t,
-               workers: List.t
-             }
+  @type t :: %KanbanVisionApi.Domain.Squad{
+          id: String.t(),
+          audit: KanbanVisionApi.Domain.Audit.t(),
+          name: String.t(),
+          workers: List.t()
+        }
 
-  def new(name, workers \\ [], id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new) do
+  def new(name, workers \\ [], id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new()) do
     initial_state = %KanbanVisionApi.Domain.Squad{
       id: id,
       audit: audit,
       name: name,
       workers: workers
     }
+
     initial_state
   end
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/step.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/step.ex
@@ -1,33 +1,32 @@
 defmodule KanbanVisionApi.Domain.Step do
   @moduledoc false
 
-  defstruct [:id, :audit, :name, :order, :requiredAbility, :tasks]
+  defstruct [:id, :audit, :name, :order, :required_ability, :tasks]
 
-  @type t :: %KanbanVisionApi.Domain.Step {
-               id: String.t,
-               audit: KanbanVisionApi.Domain.Audit.t,
-               name: String.t,
-               order: Integer.t,
-               requiredAbility: KanbanVisionApi.Domain.Ability.t,
-               tasks: List.t
-             }
+  @type t :: %KanbanVisionApi.Domain.Step{
+          id: String.t(),
+          audit: KanbanVisionApi.Domain.Audit.t(),
+          name: String.t(),
+          order: Integer.t(),
+          required_ability: KanbanVisionApi.Domain.Ability.t(),
+          tasks: List.t()
+        }
 
   def new(
         name,
         order,
-        requiredAbility \\ %KanbanVisionApi.Domain.Ability{},
+        required_ability \\ %KanbanVisionApi.Domain.Ability{},
         tasks,
         id \\ UUID.uuid4(),
-        audit \\ KanbanVisionApi.Domain.Audit.new
+        audit \\ KanbanVisionApi.Domain.Audit.new()
       ) do
-    initial_state = %KanbanVisionApi.Domain.Step{
+    %KanbanVisionApi.Domain.Step{
       id: id,
       audit: audit,
       name: name,
       order: order,
-      requiredAbility: requiredAbility,
+      required_ability: required_ability,
       tasks: tasks
     }
-    initial_state
   end
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/task.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/task.ex
@@ -3,25 +3,26 @@ defmodule KanbanVisionApi.Domain.Task do
 
   defstruct [:id, :audit, :order, :service_class]
 
-  @type t :: %KanbanVisionApi.Domain.Task {
-               id: String.t,
-               audit: KanbanVisionApi.Domain.Audit.t, 
-               order: Integer.t,
-               service_class: KanbanVisionApi.Domain.ServiceClass.t
-             }
+  @type t :: %KanbanVisionApi.Domain.Task{
+          id: String.t(),
+          audit: KanbanVisionApi.Domain.Audit.t(),
+          order: Integer.t(),
+          service_class: KanbanVisionApi.Domain.ServiceClass.t()
+        }
 
   def new(
         order,
         service_class \\ %KanbanVisionApi.Domain.ServiceClass{},
         id \\ UUID.uuid4(),
-        audit \\ KanbanVisionApi.Domain.Audit.new
+        audit \\ KanbanVisionApi.Domain.Audit.new()
       ) do
     initial_state = %KanbanVisionApi.Domain.Task{
       id: id,
-      audit: audit, 
+      audit: audit,
       order: order,
       service_class: service_class
     }
+
     initial_state
   end
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/tribe.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/tribe.ex
@@ -3,20 +3,21 @@ defmodule KanbanVisionApi.Domain.Tribe do
 
   defstruct [:id, :audit, :name, :squads]
 
-  @type t :: %KanbanVisionApi.Domain.Tribe {
-               id: String.t,
-               audit: KanbanVisionApi.Domain.Audit.t,
-               name: String.t,
-               squads: List.t
-             }
+  @type t :: %KanbanVisionApi.Domain.Tribe{
+          id: String.t(),
+          audit: KanbanVisionApi.Domain.Audit.t(),
+          name: String.t(),
+          squads: List.t()
+        }
 
-  def new(name, squads \\ [], id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new) do
+  def new(name, squads \\ [], id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new()) do
     initial_state = %KanbanVisionApi.Domain.Tribe{
       id: id,
       audit: audit,
       name: name,
       squads: squads
     }
+
     initial_state
   end
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/worker.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/worker.ex
@@ -3,20 +3,21 @@ defmodule KanbanVisionApi.Domain.Worker do
 
   defstruct [:id, :audit, :name, :abilities]
 
-  @type t :: %KanbanVisionApi.Domain.Worker {
-               id: String.t,
-               audit: KanbanVisionApi.Domain.Audit.t,
-               name: String.t,
-               abilities: List.t
-             }
+  @type t :: %KanbanVisionApi.Domain.Worker{
+          id: String.t(),
+          audit: KanbanVisionApi.Domain.Audit.t(),
+          name: String.t(),
+          abilities: List.t()
+        }
 
-  def new(name, abilities \\ [], id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new) do
+  def new(name, abilities \\ [], id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new()) do
     initial_state = %KanbanVisionApi.Domain.Worker{
       id: id,
       audit: audit,
       name: name,
       abilities: abilities
     }
+
     initial_state
   end
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/workflow.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/workflow.ex
@@ -3,18 +3,19 @@ defmodule KanbanVisionApi.Domain.Workflow do
 
   defstruct [:id, :audit, :steps]
 
-  @type t :: %KanbanVisionApi.Domain.Workflow {
-               id: String.t,
-               audit: KanbanVisionApi.Domain.Audit.t,
-               steps: List.t
-             }
+  @type t :: %KanbanVisionApi.Domain.Workflow{
+          id: String.t(),
+          audit: KanbanVisionApi.Domain.Audit.t(),
+          steps: List.t()
+        }
 
-  def new(steps \\ [], id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new) do
+  def new(steps \\ [], id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new()) do
     initial_state = %KanbanVisionApi.Domain.Workflow{
       id: id,
       audit: audit,
       steps: steps
     }
+
     initial_state
   end
 end

--- a/apps/kanban_domain/mix.exs
+++ b/apps/kanban_domain/mix.exs
@@ -26,7 +26,7 @@ defmodule Domain.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:elixir_uuid, "~> 1.2.1"},
+      {:elixir_uuid, "~> 1.2.1"}
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
       # {:sibling_app_in_umbrella, in_umbrella: true}

--- a/apps/persistence/lib/persistence.ex
+++ b/apps/persistence/lib/persistence.ex
@@ -1,18 +1,5 @@
 defmodule Persistence do
   @moduledoc """
-  Documentation for `Persistence`.
+  Agent-based persistence layer implementing the Object Prevalence pattern.
   """
-
-  @doc """
-  Hello world.
-
-  ## Examples
-
-      iex> Persistence.hello()
-      :world
-
-  """
-  def hello do
-    :world
-  end
 end

--- a/apps/persistence/test/kanban_vision_api/agent/boards_test.exs
+++ b/apps/persistence/test/kanban_vision_api/agent/boards_test.exs
@@ -6,40 +6,40 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
     setup [:prepare_empty_context]
 
     @tag :domain_boards
-    test "should not have any boards by any simulation", %{
+    test "should not have any boards by any simulation",
+         %{
            actor_pid: pid,
            boards: _boards
          } = _context do
-
       template = %{}
       assert KanbanVisionApi.Agent.Boards.get_all(pid) == template
     end
 
     @tag :domain_boards
-    test "should not have any board by simulation_id", %{
+    test "should not have any board by simulation_id",
+         %{
            actor_pid: pid,
            boards: _boards
          } = _context do
-
       template = {:error, "Boards by simulation_id: nada not found"}
       assert KanbanVisionApi.Agent.Boards.get_all_by_simulation_id(pid, "nada") == template
     end
 
     @tag :domain_boards
-    test "should be able to add a new board", %{
+    test "should be able to add a new board",
+         %{
            actor_pid: pid
          } = _context do
-
       board = KanbanVisionApi.Domain.Board.new("Dev Board", "sim-123")
       assert {:ok, ^board} = KanbanVisionApi.Agent.Boards.add(pid, board)
       assert %{} = KanbanVisionApi.Agent.Boards.get_all(pid)
     end
 
     @tag :domain_boards
-    test "should not add a board with same name and simulation_id", %{
+    test "should not add a board with same name and simulation_id",
+         %{
            actor_pid: pid
          } = _context do
-
       board = KanbanVisionApi.Domain.Board.new("Dev Board", "sim-123")
       assert {:ok, ^board} = KanbanVisionApi.Agent.Boards.add(pid, board)
 
@@ -52,32 +52,35 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
     setup [:prepare_context_with_boards]
 
     @tag :domain_boards
-    test "should get boards by simulation_id", %{
+    test "should get boards by simulation_id",
+         %{
            actor_pid: pid,
            board: board
          } = _context do
+      assert {:ok, boards} =
+               KanbanVisionApi.Agent.Boards.get_all_by_simulation_id(pid, board.simulation_id)
 
-      assert {:ok, boards} = KanbanVisionApi.Agent.Boards.get_all_by_simulation_id(pid, board.simulation_id)
       assert length(boards) == 1
     end
 
     @tag :domain_boards
-    test "should allow adding board with a different name for the same simulation_id", %{
+    test "should allow adding board with a different name for the same simulation_id",
+         %{
            actor_pid: pid,
            board: board
          } = _context do
-
       new_board = KanbanVisionApi.Domain.Board.new("QA Board", board.simulation_id)
       assert {:ok, ^new_board} = KanbanVisionApi.Agent.Boards.add(pid, new_board)
       assert 2 = map_size(KanbanVisionApi.Agent.Boards.get_all(pid))
     end
 
     @tag :domain_boards
-    test "should return error for unknown simulation_id", %{
+    test "should return error for unknown simulation_id",
+         %{
            actor_pid: pid
          } = _context do
-
-      assert {:error, _msg} = KanbanVisionApi.Agent.Boards.get_all_by_simulation_id(pid, "unknown")
+      assert {:error, _msg} =
+               KanbanVisionApi.Agent.Boards.get_all_by_simulation_id(pid, "unknown")
     end
   end
 
@@ -85,6 +88,7 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
     boards_domain = KanbanVisionApi.Agent.Boards.new()
     workflow_domain = KanbanVisionApi.Domain.Workflow.new()
     {:ok, pid} = KanbanVisionApi.Agent.Boards.start_link(boards_domain)
+
     [
       actor_pid: pid,
       boards: boards_domain,
@@ -96,6 +100,7 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
     board = KanbanVisionApi.Domain.Board.new("Dev Board", "sim-123")
     boards_domain = KanbanVisionApi.Agent.Boards.new(%{board.id => board})
     {:ok, pid} = KanbanVisionApi.Agent.Boards.start_link(boards_domain)
+
     [
       actor_pid: pid,
       boards: boards_domain,

--- a/apps/persistence/test/kanban_vision_api/agent/organizations_test.exs
+++ b/apps/persistence/test/kanban_vision_api/agent/organizations_test.exs
@@ -6,42 +6,42 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
     setup [:prepare_empty_context]
 
     @tag :domain_organizations
-    test "should not have any organization", %{
+    test "should not have any organization",
+         %{
            actor_pid: pid,
            organizations: _organizations
          } = _context do
-
       template = %{}
       assert KanbanVisionApi.Agent.Organizations.get_all(pid) == template
     end
 
     @tag :domain_organizations
-    test "should be able to add new organization", %{
+    test "should be able to add new organization",
+         %{
            actor_pid: pid,
            organizations: _organizations
          } = _context do
-
       domain = KanbanVisionApi.Domain.Organization.new("ExampleOrg")
       assert KanbanVisionApi.Agent.Organizations.add(pid, domain) == {:ok, domain}
     end
 
     @tag :domain_organizations
-    test "should be able to delete an existent organization", %{
+    test "should be able to delete an existent organization",
+         %{
            actor_pid: pid,
            organizations: _organizations
          } = _context do
-
       domain = KanbanVisionApi.Domain.Organization.new("ExampleOrg")
       assert KanbanVisionApi.Agent.Organizations.add(pid, domain) == {:ok, domain}
       assert KanbanVisionApi.Agent.Organizations.delete(pid, domain.id) == {:ok, domain}
     end
 
     @tag :domain_organizations
-    test "should not be able to delete a non-existent organization", %{
+    test "should not be able to delete a non-existent organization",
+         %{
            actor_pid: pid,
            organizations: _organizations
          } = _context do
-
       template = {:error, "Organization with id: nada not found"}
       assert KanbanVisionApi.Agent.Organizations.delete(pid, :nada) == template
     end
@@ -51,66 +51,66 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
     setup [:prepare_context_with_default_organization]
 
     @tag :domain_organizations
-    test "should has one organization", %{
+    test "should has one organization",
+         %{
            actor_pid: pid,
            organizations: _organizations,
            domain: my_domain
          } = _context do
-
       template = %{my_domain.id => my_domain}
 
       assert KanbanVisionApi.Agent.Organizations.get_all(pid) == template
     end
 
     @tag :domain_organizations
-    test "should be possible to find the organization by the id", %{
+    test "should be possible to find the organization by the id",
+         %{
            actor_pid: pid,
            organizations: _organizations,
            domain: domain
          } = _context do
-
       assert KanbanVisionApi.Agent.Organizations.get_by_id(pid, domain.id) == {:ok, domain}
     end
 
     @tag :domain_organizations
-    test "should be possible to find the organization by the name", %{
+    test "should be possible to find the organization by the name",
+         %{
            actor_pid: pid,
            organizations: _organizations,
            domain: domain
          } = _context do
-
       assert KanbanVisionApi.Agent.Organizations.get_by_name(pid, domain.name) == {:ok, [domain]}
     end
 
     @tag :domain_organizations
-    test "should not be possible to find the organization by the wrong id", %{
+    test "should not be possible to find the organization by the wrong id",
+         %{
            actor_pid: pid,
            organizations: _organizations,
            domain: _domain
          } = _context do
-
       template = {:error, "Organization with id: nada not found"}
       assert KanbanVisionApi.Agent.Organizations.get_by_id(pid, :nada) == template
     end
 
     @tag :domain_organizations
-    test "should no be possible to find the organization by the wrong name", %{
+    test "should no be possible to find the organization by the wrong name",
+         %{
            actor_pid: pid,
            organizations: _organizations,
            domain: _domain
          } = _context do
-
       template = {:error, "Organization with name: Invalid Name not found"}
       assert KanbanVisionApi.Agent.Organizations.get_by_name(pid, "Invalid Name") == template
     end
 
     @tag :domain_organizations
-    test "should no be possible to add one organization with the name already exist", %{
+    test "should no be possible to add one organization with the name already exist",
+         %{
            actor_pid: pid,
            organizations: _organizations,
            domain: domain
          } = _context do
-
       template = {:error, "Organization with name: ExampleOrg already exist"}
       assert KanbanVisionApi.Agent.Organizations.add(pid, domain) == template
     end
@@ -119,6 +119,7 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
   defp prepare_empty_context(_context) do
     organizations_domain = KanbanVisionApi.Agent.Organizations.new()
     {:ok, pid} = KanbanVisionApi.Agent.Organizations.start_link(organizations_domain)
+
     [
       actor_pid: pid,
       organizations: organizations_domain
@@ -128,14 +129,15 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
   defp prepare_context_with_default_organization(_context) do
     organization_domain = KanbanVisionApi.Domain.Organization.new("ExampleOrg")
 
-    initial_state = KanbanVisionApi.Agent.Organizations.new(%{organization_domain.id => organization_domain})
+    initial_state =
+      KanbanVisionApi.Agent.Organizations.new(%{organization_domain.id => organization_domain})
 
     {:ok, pid} = KanbanVisionApi.Agent.Organizations.start_link(initial_state)
+
     [
       actor_pid: pid,
       organizations: initial_state,
       domain: organization_domain
     ]
   end
-
 end

--- a/apps/persistence/test/kanban_vision_api/agent/simulations_test.exs
+++ b/apps/persistence/test/kanban_vision_api/agent/simulations_test.exs
@@ -6,111 +6,118 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
     setup [:prepare_empty_context]
 
     @tag :domain_smulations
-    test "should not have any simulation for any organization", %{
+    test "should not have any simulation for any organization",
+         %{
            actor_pid: pid,
            simulations: _simulations,
            organization: _organization
          } = _context do
-
       template = %{}
 
       assert KanbanVisionApi.Agent.Simulations.get_all(pid) == template
     end
 
     @tag :domain_smulations
-    test "should be able to add a new simulation to a specific organization", %{
+    test "should be able to add a new simulation to a specific organization",
+         %{
            actor_pid: pid,
            simulations: _simulations,
            organization: organization
          } = _context do
+      simulation_domain =
+        KanbanVisionApi.Domain.Simulation.new(
+          "ExampleSimulation",
+          "ExampleSimulationDescription",
+          organization.id
+        )
 
-      simulation_domain = KanbanVisionApi.Domain.Simulation.new(
-        "ExampleSimulation",
-        "ExampleSimulationDescription",
-        organization.id
-      )
-
-      assert KanbanVisionApi.Agent.Simulations.add(pid, simulation_domain) == {:ok, simulation_domain}
+      assert KanbanVisionApi.Agent.Simulations.add(pid, simulation_domain) ==
+               {:ok, simulation_domain}
     end
   end
-  
+
   describe "When the system is already started and already has data" do
     setup [:prepare_context_with_data]
 
     @tag :domain_smulations
-    test "should be able to get all simulations for a specific organization", %{
+    test "should be able to get all simulations for a specific organization",
+         %{
            actor_pid: pid,
            simulations: _simulations,
            simulation: simulation,
            organization: organization
          } = _context do
-
       template = %{organization.id => %{simulation.id => simulation}}
 
       assert KanbanVisionApi.Agent.Simulations.get_all(pid) == template
     end
 
     @tag :domain_smulations
-    test "should be able to add a new simulation to a specific organization", %{
+    test "should be able to add a new simulation to a specific organization",
+         %{
            actor_pid: pid,
            simulations: _simulations,
            simulation: simulation,
            organization: organization
          } = _context do
-
-      new_simulation = KanbanVisionApi.Domain.Simulation.new(
-        "AnotherExampleOfSimulation",
-        "AnotherExampleOfSimulationDescription",
-        organization.id
-      )
+      new_simulation =
+        KanbanVisionApi.Domain.Simulation.new(
+          "AnotherExampleOfSimulation",
+          "AnotherExampleOfSimulationDescription",
+          organization.id
+        )
 
       assert KanbanVisionApi.Agent.Simulations.add(pid, new_simulation) == {:ok, new_simulation}
 
-      template = %{organization.id => %{new_simulation.id => new_simulation, simulation.id => simulation}}
+      template = %{
+        organization.id => %{new_simulation.id => new_simulation, simulation.id => simulation}
+      }
 
       assert KanbanVisionApi.Agent.Simulations.get_all(pid) == template
     end
 
     @tag :domain_smulations
-    test "Try to add a simulation that already exists", %{
+    test "Try to add a simulation that already exists",
+         %{
            actor_pid: pid,
            simulations: _simulations,
            simulation: simulation,
            organization: _organization
          } = _context do
-
       assert KanbanVisionApi.Agent.Simulations.add(pid, simulation) == {
-        :error,
-        """
-        Simulation with organization_id: #{simulation.organization_id}
-        name: #{simulation.name} already exist
-        """
-      }
+               :error,
+               """
+               Simulation with organization_id: #{simulation.organization_id}
+               name: #{simulation.name} already exist
+               """
+             }
     end
 
     @tag :domain_smulations
-    test "try to find a simulation on a non existent organization", %{
+    test "try to find a simulation on a non existent organization",
+         %{
            actor_pid: pid,
            simulations: _simulations,
            organization: _organization
          } = _context do
-
       template = {:error, "Simulation with organization id: INVALID not found"}
 
-      assert KanbanVisionApi.Agent.Simulations
-             .get_by_organization_id_and_simulation_name(pid, "INVALID", "Simulation Name") == template
+      assert KanbanVisionApi.Agent.Simulations.get_by_organization_id_and_simulation_name(
+               pid,
+               "INVALID",
+               "Simulation Name"
+             ) == template
     end
 
     @tag :domain_smulations
-    test "try to find a simulation by name that does not exist", %{
+    test "try to find a simulation by name that does not exist",
+         %{
            actor_pid: pid,
            organization: organization
          } = _context do
-
       template = {:error, "Simulation with name: Missing Simulation not found"}
 
-      assert KanbanVisionApi.Agent.Simulations
-             .get_by_organization_id_and_simulation_name(
+      assert KanbanVisionApi.Agent.Simulations.get_by_organization_id_and_simulation_name(
                pid,
                organization.id,
                "Missing Simulation"
@@ -122,15 +129,14 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
     setup [:prepare_context_with_empty_org]
 
     @tag :domain_smulations
-    test "should return error for missing simulations on existing organization", %{
+    test "should return error for missing simulations on existing organization",
+         %{
            actor_pid: pid,
            organization: organization
          } = _context do
-
       template = {:error, "Simulation with organization id: #{organization.id} not found"}
 
-      assert KanbanVisionApi.Agent.Simulations
-             .get_by_organization_id_and_simulation_name(
+      assert KanbanVisionApi.Agent.Simulations.get_by_organization_id_and_simulation_name(
                pid,
                organization.id,
                "Any Simulation"
@@ -142,6 +148,7 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
     simulations_domain = KanbanVisionApi.Agent.Simulations.new()
     organization_domain = KanbanVisionApi.Domain.Organization.new("ExampleOrg")
     {:ok, pid} = KanbanVisionApi.Agent.Simulations.start_link(simulations_domain)
+
     [
       actor_pid: pid,
       simulations: simulations_domain,
@@ -151,15 +158,18 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
 
   defp prepare_context_with_data(_context) do
     organization_domain = KanbanVisionApi.Domain.Organization.new("ExampleOrg")
-    simulation_domain = KanbanVisionApi.Domain.Simulation.new(
-      "ExampleSimulation",
-      "ExampleSimulationDescription",
-      organization_domain.id
-    )
+
+    simulation_domain =
+      KanbanVisionApi.Domain.Simulation.new(
+        "ExampleSimulation",
+        "ExampleSimulationDescription",
+        organization_domain.id
+      )
 
     simulations_by_organization = %{
       organization_domain.id => %{simulation_domain.id => simulation_domain}
     }
+
     simulations_domain = KanbanVisionApi.Agent.Simulations.new(simulations_by_organization)
 
     {:ok, pid} = KanbanVisionApi.Agent.Simulations.start_link(simulations_domain)

--- a/apps/persistence/test/persistence_test.exs
+++ b/apps/persistence/test/persistence_test.exs
@@ -1,8 +1,3 @@
 defmodule PersistenceTest do
   use ExUnit.Case
-  doctest Persistence
-
-  test "greets the world" do
-    assert Persistence.hello() == :world
-  end
 end

--- a/apps/usecase/lib/kanban_vision_api/usecase/organization/commands.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organization/commands.ex
@@ -1,0 +1,9 @@
+defmodule KanbanVisionApi.Usecase.Organization.CreateOrganizationCommand do
+  @moduledoc false
+  defstruct [:name, tribes: []]
+end
+
+defmodule KanbanVisionApi.Usecase.Organization.DeleteOrganizationCommand do
+  @moduledoc false
+  defstruct [:id]
+end

--- a/apps/usecase/lib/kanban_vision_api/usecase/organization/queries.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organization/queries.ex
@@ -1,0 +1,9 @@
+defmodule KanbanVisionApi.Usecase.Organization.GetOrganizationByIdQuery do
+  @moduledoc false
+  defstruct [:id]
+end
+
+defmodule KanbanVisionApi.Usecase.Organization.GetOrganizationByNameQuery do
+  @moduledoc false
+  defstruct [:name]
+end

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulation/commands.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulation/commands.ex
@@ -1,0 +1,4 @@
+defmodule KanbanVisionApi.Usecase.Simulation.CreateSimulationCommand do
+  @moduledoc false
+  defstruct [:name, :description, :organization_id]
+end

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulation/queries.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulation/queries.ex
@@ -1,0 +1,4 @@
+defmodule KanbanVisionApi.Usecase.Simulation.GetSimulationByOrgAndNameQuery do
+  @moduledoc false
+  defstruct [:organization_id, :name]
+end

--- a/apps/usecase/lib/usecase.ex
+++ b/apps/usecase/lib/usecase.ex
@@ -1,18 +1,5 @@
 defmodule Usecase do
   @moduledoc """
-  Documentation for `Usecase`.
+  GenServer-based application layer that orchestrates domain operations.
   """
-
-  @doc """
-  Hello world.
-
-  ## Examples
-
-      iex> Usecase.hello()
-      :world
-
-  """
-  def hello do
-    :world
-  end
 end

--- a/apps/usecase/mix.exs
+++ b/apps/usecase/mix.exs
@@ -29,7 +29,8 @@ defmodule Usecase.MixProject do
     [
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
-      {:kanban_domain, in_umbrella: true}
+      {:kanban_domain, in_umbrella: true},
+      {:persistence, in_umbrella: true}
     ]
   end
 end

--- a/apps/usecase/test/kanban_vision_api/usecase/organization_test.exs
+++ b/apps/usecase/test/kanban_vision_api/usecase/organization_test.exs
@@ -1,5 +1,72 @@
 defmodule KanbanVisionApi.Usecase.OrganizationTest do
   use ExUnit.Case, async: true
-  doctest KanbanVisionApi.Usecase.Organization
 
+  alias KanbanVisionApi.Usecase.Organization
+  alias KanbanVisionApi.Usecase.Organization.CreateOrganizationCommand
+  alias KanbanVisionApi.Usecase.Organization.DeleteOrganizationCommand
+  alias KanbanVisionApi.Usecase.Organization.GetOrganizationByIdQuery
+  alias KanbanVisionApi.Usecase.Organization.GetOrganizationByNameQuery
+
+  describe "When start with empty state" do
+    setup [:start_usecase]
+
+    test "should return empty map", %{pid: pid} do
+      assert Organization.get_all(pid) == {:ok, %{}}
+    end
+
+    test "should add a new organization via command", %{pid: pid} do
+      cmd = %CreateOrganizationCommand{name: "TestOrg"}
+      assert {:ok, org} = Organization.add(pid, cmd)
+      assert org.name == "TestOrg"
+      assert org.id != nil
+    end
+
+    test "should find organization by id via query", %{pid: pid} do
+      cmd = %CreateOrganizationCommand{name: "TestOrg"}
+      {:ok, org} = Organization.add(pid, cmd)
+
+      query = %GetOrganizationByIdQuery{id: org.id}
+      assert {:ok, ^org} = Organization.get_by_id(pid, query)
+    end
+
+    test "should find organization by name via query", %{pid: pid} do
+      cmd = %CreateOrganizationCommand{name: "TestOrg"}
+      {:ok, org} = Organization.add(pid, cmd)
+
+      query = %GetOrganizationByNameQuery{name: "TestOrg"}
+      assert {:ok, [^org]} = Organization.get_by_name(pid, query)
+    end
+
+    test "should delete an organization via command", %{pid: pid} do
+      cmd = %CreateOrganizationCommand{name: "TestOrg"}
+      {:ok, org} = Organization.add(pid, cmd)
+
+      delete_cmd = %DeleteOrganizationCommand{id: org.id}
+      assert {:ok, ^org} = Organization.delete(pid, delete_cmd)
+      assert {:ok, %{}} = Organization.get_all(pid)
+    end
+
+    test "should return error for non-existent id", %{pid: pid} do
+      query = %GetOrganizationByIdQuery{id: "invalid"}
+      assert {:error, _} = Organization.get_by_id(pid, query)
+    end
+
+    test "should return error for non-existent name", %{pid: pid} do
+      query = %GetOrganizationByNameQuery{name: "Invalid"}
+      assert {:error, _} = Organization.get_by_name(pid, query)
+    end
+
+    test "should not allow duplicate organization names", %{pid: pid} do
+      cmd = %CreateOrganizationCommand{name: "TestOrg"}
+      {:ok, _} = Organization.add(pid, cmd)
+
+      cmd2 = %CreateOrganizationCommand{name: "TestOrg"}
+      assert {:error, _} = Organization.add(pid, cmd2)
+    end
+  end
+
+  defp start_usecase(_context) do
+    {:ok, pid} = Organization.start_link()
+    [pid: pid]
+  end
 end

--- a/apps/usecase/test/kanban_vision_api/usecase/simulation_test.exs
+++ b/apps/usecase/test/kanban_vision_api/usecase/simulation_test.exs
@@ -1,12 +1,54 @@
 defmodule KanbanVisionApi.Usecase.SimulationTest do
   use ExUnit.Case, async: true
-  doctest KanbanVisionApi.Usecase.Simulation
 
-  describe "When start a new simulation with empty state" do
-    test "should be empty" do
-      {:ok, pid} = KanbanVisionApi.Usecase.Simulation.start_link()
-      assert KanbanVisionApi.Usecase.Simulation.fetch(pid) == {:ok, %{}}
+  alias KanbanVisionApi.Usecase.Simulation
+  alias KanbanVisionApi.Usecase.Simulation.CreateSimulationCommand
+  alias KanbanVisionApi.Usecase.Simulation.GetSimulationByOrgAndNameQuery
+
+  describe "When start with empty state" do
+    setup [:start_usecase]
+
+    test "should return empty map", %{pid: pid} do
+      assert Simulation.get_all(pid) == {:ok, %{}}
+    end
+
+    test "should add a new simulation via command", %{pid: pid} do
+      org = KanbanVisionApi.Domain.Organization.new("TestOrg")
+
+      cmd = %CreateSimulationCommand{
+        name: "TestSim",
+        description: "Description",
+        organization_id: org.id
+      }
+
+      assert {:ok, sim} = Simulation.add(pid, cmd)
+      assert sim.name == "TestSim"
+      assert sim.organization_id == org.id
+    end
+
+    test "should find simulation by org and name via query", %{pid: pid} do
+      org = KanbanVisionApi.Domain.Organization.new("TestOrg")
+
+      cmd = %CreateSimulationCommand{
+        name: "TestSim",
+        description: "Description",
+        organization_id: org.id
+      }
+
+      {:ok, sim} = Simulation.add(pid, cmd)
+
+      query = %GetSimulationByOrgAndNameQuery{organization_id: org.id, name: "TestSim"}
+      assert {:ok, ^sim} = Simulation.get_by_org_and_name(pid, query)
+    end
+
+    test "should return error for non-existent simulation", %{pid: pid} do
+      query = %GetSimulationByOrgAndNameQuery{organization_id: "invalid", name: "Invalid"}
+      assert {:error, _} = Simulation.get_by_org_and_name(pid, query)
     end
   end
 
+  defp start_usecase(_context) do
+    {:ok, pid} = Simulation.start_link()
+    [pid: pid]
+  end
 end


### PR DESCRIPTION
## Summary

- **Domain fixes**: Rename `requiredAbility` → `required_ability` (snake_case convention), add missing `:audit` field to `Project` entity
- **Ports & Adapters**: Define `OrganizationRepository`, `SimulationRepository`, and `BoardRepository` behaviours in `domain/ports/`; Agents declare `@behaviour` implementing these contracts
- **Eliminate duplication**: Usecase GenServers now delegate to persistence Agents instead of reimplementing query/validation logic internally
- **Command/Query DTOs**: Introduce `CreateOrganizationCommand`, `DeleteOrganizationCommand`, `GetOrganizationByIdQuery`, `GetOrganizationByNameQuery`, `CreateSimulationCommand`, `GetSimulationByOrgAndNameQuery` — use cases accept DTOs and create domain entities internally
- **Cleanup**: Remove placeholder `hello/0` functions, fix credo pattern-matching consistency, apply `mix format` across all files

## Test plan

- [x] `mix test` — 37 tests pass (25 persistence + 12 usecase)
- [x] `mix credo` — no issues found
- [x] `mix format --check-formatted` — all files properly formatted
- [x] `mix compile --warnings-as-errors` — no warnings (behaviour compliance verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)