### PR TITLE
Refactor: Apply best practices across domain, ports, and use cases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,9 +270,12 @@ When creating a new service or microservice, include from the start:
 
 Before completing a task, read the relevant skill:
 
-| Task | Skill |
-|------|-------|
+| Task                                              | Skill                               |
+|---------------------------------------------------|-------------------------------------|
 | Finishing any feature, bug fix, or tech debt item | `docs/skills/definition-of-done.md` |
+| How to use Flow in a performatic way              | `docs/skills/FLOW.md`               |
+| How to use GenStage in a performatic way          | `docs/skills/GenStage.md`           |
+| How to use Elixir in a performatic way            | `docs/skills/Elixir.md`             |
 
 **The Definition of Done skill is mandatory before declaring any task complete.**
 

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/ability.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/ability.ex
@@ -1,16 +1,18 @@
 defmodule KanbanVisionApi.Domain.Ability do
   @moduledoc false
 
+  alias KanbanVisionApi.Domain.Audit
+
   defstruct [:id, :audit, :name]
 
-  @type t :: %KanbanVisionApi.Domain.Ability{
+  @type t :: %__MODULE__{
           id: String.t(),
-          audit: KanbanVisionApi.Domain.Audit.t(),
+          audit: Audit.t(),
           name: String.t()
         }
 
-  def new(name, id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new()) do
-    %KanbanVisionApi.Domain.Ability{
+  def new(name, id \\ UUID.uuid4(), audit \\ Audit.new()) do
+    %__MODULE__{
       id: id,
       audit: audit,
       name: name

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/audit.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/audit.ex
@@ -4,8 +4,8 @@ defmodule KanbanVisionApi.Domain.Audit do
   defstruct [:created, :updated]
 
   @type t :: %KanbanVisionApi.Domain.Audit{
-          created: DateTime,
-          updated: DateTime
+          created: DateTime.t(),
+          updated: DateTime.t()
         }
 
   def new do

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/audit.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/audit.ex
@@ -3,13 +3,13 @@ defmodule KanbanVisionApi.Domain.Audit do
 
   defstruct [:created, :updated]
 
-  @type t :: %KanbanVisionApi.Domain.Audit{
+  @type t :: %__MODULE__{
           created: DateTime.t(),
           updated: DateTime.t()
         }
 
   def new do
-    %KanbanVisionApi.Domain.Audit{
+    %__MODULE__{
       created: DateTime.utc_now(),
       updated: DateTime.utc_now()
     }

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/board.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/board.ex
@@ -9,7 +9,7 @@ defmodule KanbanVisionApi.Domain.Board do
           name: String.t(),
           simulation_id: String.t(),
           workflow: KanbanVisionApi.Domain.Workflow.t(),
-          workers: List.t()
+          workers: %{optional(String.t()) => KanbanVisionApi.Domain.Worker.t()}
         }
 
   def new(
@@ -20,7 +20,7 @@ defmodule KanbanVisionApi.Domain.Board do
         id \\ UUID.uuid4(),
         audit \\ KanbanVisionApi.Domain.Audit.new()
       ) do
-    initial_state = %KanbanVisionApi.Domain.Board{
+    %KanbanVisionApi.Domain.Board{
       id: id,
       audit: audit,
       name: name,
@@ -28,7 +28,5 @@ defmodule KanbanVisionApi.Domain.Board do
       workflow: workflow,
       workers: workers
     }
-
-    initial_state
   end
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/board.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/board.ex
@@ -1,26 +1,30 @@
 defmodule KanbanVisionApi.Domain.Board do
   @moduledoc false
 
+  alias KanbanVisionApi.Domain.Audit
+  alias KanbanVisionApi.Domain.Worker
+  alias KanbanVisionApi.Domain.Workflow
+
   defstruct [:id, :audit, :name, :simulation_id, :workflow, :workers]
 
-  @type t :: %KanbanVisionApi.Domain.Board{
+  @type t :: %__MODULE__{
           id: String.t(),
-          audit: KanbanVisionApi.Domain.Audit.t(),
+          audit: Audit.t(),
           name: String.t(),
           simulation_id: String.t(),
-          workflow: KanbanVisionApi.Domain.Workflow.t(),
-          workers: %{optional(String.t()) => KanbanVisionApi.Domain.Worker.t()}
+          workflow: Workflow.t(),
+          workers: %{optional(String.t()) => Worker.t()}
         }
 
   def new(
         name \\ "Default",
         simulation_id \\ "Default Simulation ID",
-        workflow \\ %KanbanVisionApi.Domain.Workflow{},
+        workflow \\ %Workflow{},
         workers \\ %{},
         id \\ UUID.uuid4(),
-        audit \\ KanbanVisionApi.Domain.Audit.new()
+        audit \\ Audit.new()
       ) do
-    %KanbanVisionApi.Domain.Board{
+    %__MODULE__{
       id: id,
       audit: audit,
       name: name,

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/organization.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/organization.ex
@@ -7,7 +7,7 @@ defmodule KanbanVisionApi.Domain.Organization do
           id: String.t(),
           audit: KanbanVisionApi.Domain.Audit.t(),
           name: String.t(),
-          tribes: List.t()
+          tribes: [KanbanVisionApi.Domain.Tribe.t()]
         }
 
   def new(name, tribes \\ [], id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new()) do

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/organization.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/organization.ex
@@ -1,17 +1,20 @@
 defmodule KanbanVisionApi.Domain.Organization do
   @moduledoc false
 
+  alias KanbanVisionApi.Domain.Audit
+  alias KanbanVisionApi.Domain.Tribe
+
   defstruct [:id, :audit, :name, :tribes]
 
-  @type t :: %KanbanVisionApi.Domain.Organization{
+  @type t :: %__MODULE__{
           id: String.t(),
-          audit: KanbanVisionApi.Domain.Audit.t(),
+          audit: Audit.t(),
           name: String.t(),
-          tribes: [KanbanVisionApi.Domain.Tribe.t()]
+          tribes: [Tribe.t()]
         }
 
-  def new(name, tribes \\ [], id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new()) do
-    %KanbanVisionApi.Domain.Organization{
+  def new(name, tribes \\ [], id \\ UUID.uuid4(), audit \\ Audit.new()) do
+    %__MODULE__{
       id: id,
       audit: audit,
       name: name,

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/ports/board_repository.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/ports/board_repository.ex
@@ -3,8 +3,10 @@ defmodule KanbanVisionApi.Domain.Ports.BoardRepository do
   Port defining the contract for board persistence.
   """
 
+  alias KanbanVisionApi.Domain.Board
+
   @callback get_all(pid :: pid()) :: map()
-  @callback add(pid :: pid(), board :: struct()) :: {:ok, struct()} | {:error, String.t()}
+  @callback add(pid :: pid(), board :: Board.t()) :: {:ok, Board.t()} | {:error, String.t()}
   @callback get_all_by_simulation_id(pid :: pid(), simulation_id :: String.t()) ::
-              {:ok, list()} | {:error, String.t()}
+              {:ok, [Board.t()]} | {:error, String.t()}
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/ports/organization_repository.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/ports/organization_repository.ex
@@ -3,9 +3,15 @@ defmodule KanbanVisionApi.Domain.Ports.OrganizationRepository do
   Port defining the contract for organization persistence.
   """
 
+  alias KanbanVisionApi.Domain.Organization
+
   @callback get_all(pid :: pid()) :: map()
-  @callback get_by_id(pid :: pid(), id :: String.t()) :: {:ok, struct()} | {:error, String.t()}
-  @callback get_by_name(pid :: pid(), name :: String.t()) :: {:ok, list()} | {:error, String.t()}
-  @callback add(pid :: pid(), organization :: struct()) :: {:ok, struct()} | {:error, String.t()}
-  @callback delete(pid :: pid(), id :: String.t()) :: {:ok, struct()} | {:error, String.t()}
+  @callback get_by_id(pid :: pid(), id :: String.t()) ::
+              {:ok, Organization.t()} | {:error, String.t()}
+  @callback get_by_name(pid :: pid(), name :: String.t()) ::
+              {:ok, [Organization.t()]} | {:error, String.t()}
+  @callback add(pid :: pid(), organization :: Organization.t()) ::
+              {:ok, Organization.t()} | {:error, String.t()}
+  @callback delete(pid :: pid(), id :: String.t()) ::
+              {:ok, Organization.t()} | {:error, String.t()}
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/ports/simulation_repository.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/ports/simulation_repository.ex
@@ -3,11 +3,14 @@ defmodule KanbanVisionApi.Domain.Ports.SimulationRepository do
   Port defining the contract for simulation persistence.
   """
 
+  alias KanbanVisionApi.Domain.Simulation
+
   @callback get_all(pid :: pid()) :: map()
-  @callback add(pid :: pid(), simulation :: struct()) :: {:ok, struct()} | {:error, String.t()}
+  @callback add(pid :: pid(), simulation :: Simulation.t()) ::
+              {:ok, Simulation.t()} | {:error, String.t()}
   @callback get_by_organization_id_and_simulation_name(
               pid :: pid(),
               org_id :: String.t(),
               name :: String.t()
-            ) :: {:ok, struct()} | {:error, String.t()}
+            ) :: {:ok, Simulation.t()} | {:error, String.t()}
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/project.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/project.ex
@@ -1,14 +1,17 @@
 defmodule KanbanVisionApi.Domain.Project do
   @moduledoc false
 
+  alias KanbanVisionApi.Domain.Audit
+  alias KanbanVisionApi.Domain.Task
+
   defstruct [:id, :audit, :name, :order, :tasks]
 
-  @type t :: %KanbanVisionApi.Domain.Project{
+  @type t :: %__MODULE__{
           id: String.t(),
-          audit: KanbanVisionApi.Domain.Audit.t(),
+          audit: Audit.t(),
           name: String.t(),
           order: non_neg_integer(),
-          tasks: [KanbanVisionApi.Domain.Task.t()]
+          tasks: [Task.t()]
         }
 
   def new(
@@ -16,9 +19,9 @@ defmodule KanbanVisionApi.Domain.Project do
         order \\ 0,
         tasks \\ [],
         id \\ UUID.uuid4(),
-        audit \\ KanbanVisionApi.Domain.Audit.new()
+        audit \\ Audit.new()
       ) do
-    %KanbanVisionApi.Domain.Project{
+    %__MODULE__{
       id: id,
       audit: audit,
       name: name,

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/project.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/project.ex
@@ -7,8 +7,8 @@ defmodule KanbanVisionApi.Domain.Project do
           id: String.t(),
           audit: KanbanVisionApi.Domain.Audit.t(),
           name: String.t(),
-          order: Integer.t(),
-          tasks: List.t(KanbanVisionApi.Domain.Task.t())
+          order: non_neg_integer(),
+          tasks: [KanbanVisionApi.Domain.Task.t()]
         }
 
   def new(

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/service_class.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/service_class.ex
@@ -1,16 +1,18 @@
 defmodule KanbanVisionApi.Domain.ServiceClass do
   @moduledoc false
 
+  alias KanbanVisionApi.Domain.Audit
+
   defstruct [:id, :audit, :name]
 
-  @type t :: %KanbanVisionApi.Domain.ServiceClass{
+  @type t :: %__MODULE__{
           id: String.t(),
-          audit: KanbanVisionApi.Domain.Audit.t(),
+          audit: Audit.t(),
           name: String.t()
         }
 
-  def new(name, id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new()) do
-    %KanbanVisionApi.Domain.ServiceClass{
+  def new(name, id \\ UUID.uuid4(), audit \\ Audit.new()) do
+    %__MODULE__{
       id: id,
       audit: audit,
       name: name

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/service_class.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/service_class.ex
@@ -10,12 +10,10 @@ defmodule KanbanVisionApi.Domain.ServiceClass do
         }
 
   def new(name, id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new()) do
-    initial_state = %KanbanVisionApi.Domain.ServiceClass{
+    %KanbanVisionApi.Domain.ServiceClass{
       id: id,
       audit: audit,
       name: name
     }
-
-    initial_state
   end
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/simulation.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/simulation.ex
@@ -10,7 +10,7 @@ defmodule KanbanVisionApi.Domain.Simulation do
           description: String.t(),
           organization_id: String.t(),
           board: KanbanVisionApi.Domain.Board.t() | nil,
-          default_projects: List.t(KanbanVisionApi.Domain.Project.t())
+          default_projects: [KanbanVisionApi.Domain.Project.t()]
         }
 
   def new(

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/simulation.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/simulation.ex
@@ -1,28 +1,32 @@
 defmodule KanbanVisionApi.Domain.Simulation do
   @moduledoc false
 
+  alias KanbanVisionApi.Domain.Audit
+  alias KanbanVisionApi.Domain.Board
+  alias KanbanVisionApi.Domain.Project
+
   defstruct [:id, :audit, :name, :description, :organization_id, :board, :default_projects]
 
-  @type t :: %KanbanVisionApi.Domain.Simulation{
+  @type t :: %__MODULE__{
           id: String.t(),
-          audit: KanbanVisionApi.Domain.Audit.t(),
+          audit: Audit.t(),
           name: String.t(),
           description: String.t(),
           organization_id: String.t(),
-          board: KanbanVisionApi.Domain.Board.t() | nil,
-          default_projects: [KanbanVisionApi.Domain.Project.t()]
+          board: Board.t() | nil,
+          default_projects: [Project.t()]
         }
 
   def new(
         name,
         description \\ "Default Simulation Name",
         organization_id,
-        board \\ KanbanVisionApi.Domain.Board.new(),
+        board \\ Board.new(),
         default_projects \\ [],
         id \\ UUID.uuid4(),
-        audit \\ KanbanVisionApi.Domain.Audit.new()
+        audit \\ Audit.new()
       ) do
-    %KanbanVisionApi.Domain.Simulation{
+    %__MODULE__{
       id: id,
       audit: audit,
       name: name,

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/squad.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/squad.ex
@@ -1,17 +1,20 @@
 defmodule KanbanVisionApi.Domain.Squad do
   @moduledoc false
 
+  alias KanbanVisionApi.Domain.Audit
+  alias KanbanVisionApi.Domain.Worker
+
   defstruct [:id, :audit, :name, :workers]
 
-  @type t :: %KanbanVisionApi.Domain.Squad{
+  @type t :: %__MODULE__{
           id: String.t(),
-          audit: KanbanVisionApi.Domain.Audit.t(),
+          audit: Audit.t(),
           name: String.t(),
-          workers: [KanbanVisionApi.Domain.Worker.t()]
+          workers: [Worker.t()]
         }
 
-  def new(name, workers \\ [], id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new()) do
-    %KanbanVisionApi.Domain.Squad{
+  def new(name, workers \\ [], id \\ UUID.uuid4(), audit \\ Audit.new()) do
+    %__MODULE__{
       id: id,
       audit: audit,
       name: name,

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/squad.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/squad.ex
@@ -7,17 +7,15 @@ defmodule KanbanVisionApi.Domain.Squad do
           id: String.t(),
           audit: KanbanVisionApi.Domain.Audit.t(),
           name: String.t(),
-          workers: List.t()
+          workers: [KanbanVisionApi.Domain.Worker.t()]
         }
 
   def new(name, workers \\ [], id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new()) do
-    initial_state = %KanbanVisionApi.Domain.Squad{
+    %KanbanVisionApi.Domain.Squad{
       id: id,
       audit: audit,
       name: name,
       workers: workers
     }
-
-    initial_state
   end
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/step.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/step.ex
@@ -1,26 +1,30 @@
 defmodule KanbanVisionApi.Domain.Step do
   @moduledoc false
 
+  alias KanbanVisionApi.Domain.Ability
+  alias KanbanVisionApi.Domain.Audit
+  alias KanbanVisionApi.Domain.Task
+
   defstruct [:id, :audit, :name, :order, :required_ability, :tasks]
 
-  @type t :: %KanbanVisionApi.Domain.Step{
+  @type t :: %__MODULE__{
           id: String.t(),
-          audit: KanbanVisionApi.Domain.Audit.t(),
+          audit: Audit.t(),
           name: String.t(),
           order: non_neg_integer(),
-          required_ability: KanbanVisionApi.Domain.Ability.t(),
-          tasks: [KanbanVisionApi.Domain.Task.t()]
+          required_ability: Ability.t(),
+          tasks: [Task.t()]
         }
 
   def new(
         name,
         order,
-        required_ability \\ %KanbanVisionApi.Domain.Ability{},
+        required_ability \\ %Ability{},
         tasks,
         id \\ UUID.uuid4(),
-        audit \\ KanbanVisionApi.Domain.Audit.new()
+        audit \\ Audit.new()
       ) do
-    %KanbanVisionApi.Domain.Step{
+    %__MODULE__{
       id: id,
       audit: audit,
       name: name,

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/step.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/step.ex
@@ -7,9 +7,9 @@ defmodule KanbanVisionApi.Domain.Step do
           id: String.t(),
           audit: KanbanVisionApi.Domain.Audit.t(),
           name: String.t(),
-          order: Integer.t(),
+          order: non_neg_integer(),
           required_ability: KanbanVisionApi.Domain.Ability.t(),
-          tasks: List.t()
+          tasks: [KanbanVisionApi.Domain.Task.t()]
         }
 
   def new(

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/task.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/task.ex
@@ -1,22 +1,25 @@
 defmodule KanbanVisionApi.Domain.Task do
   @moduledoc false
 
+  alias KanbanVisionApi.Domain.Audit
+  alias KanbanVisionApi.Domain.ServiceClass
+
   defstruct [:id, :audit, :order, :service_class]
 
-  @type t :: %KanbanVisionApi.Domain.Task{
+  @type t :: %__MODULE__{
           id: String.t(),
-          audit: KanbanVisionApi.Domain.Audit.t(),
+          audit: Audit.t(),
           order: non_neg_integer(),
-          service_class: KanbanVisionApi.Domain.ServiceClass.t()
+          service_class: ServiceClass.t()
         }
 
   def new(
         order,
-        service_class \\ %KanbanVisionApi.Domain.ServiceClass{},
+        service_class \\ %ServiceClass{},
         id \\ UUID.uuid4(),
-        audit \\ KanbanVisionApi.Domain.Audit.new()
+        audit \\ Audit.new()
       ) do
-    %KanbanVisionApi.Domain.Task{
+    %__MODULE__{
       id: id,
       audit: audit,
       order: order,

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/task.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/task.ex
@@ -6,7 +6,7 @@ defmodule KanbanVisionApi.Domain.Task do
   @type t :: %KanbanVisionApi.Domain.Task{
           id: String.t(),
           audit: KanbanVisionApi.Domain.Audit.t(),
-          order: Integer.t(),
+          order: non_neg_integer(),
           service_class: KanbanVisionApi.Domain.ServiceClass.t()
         }
 
@@ -16,13 +16,11 @@ defmodule KanbanVisionApi.Domain.Task do
         id \\ UUID.uuid4(),
         audit \\ KanbanVisionApi.Domain.Audit.new()
       ) do
-    initial_state = %KanbanVisionApi.Domain.Task{
+    %KanbanVisionApi.Domain.Task{
       id: id,
       audit: audit,
       order: order,
       service_class: service_class
     }
-
-    initial_state
   end
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/tribe.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/tribe.ex
@@ -7,17 +7,15 @@ defmodule KanbanVisionApi.Domain.Tribe do
           id: String.t(),
           audit: KanbanVisionApi.Domain.Audit.t(),
           name: String.t(),
-          squads: List.t()
+          squads: [KanbanVisionApi.Domain.Squad.t()]
         }
 
   def new(name, squads \\ [], id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new()) do
-    initial_state = %KanbanVisionApi.Domain.Tribe{
+    %KanbanVisionApi.Domain.Tribe{
       id: id,
       audit: audit,
       name: name,
       squads: squads
     }
-
-    initial_state
   end
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/tribe.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/tribe.ex
@@ -1,17 +1,20 @@
 defmodule KanbanVisionApi.Domain.Tribe do
   @moduledoc false
 
+  alias KanbanVisionApi.Domain.Audit
+  alias KanbanVisionApi.Domain.Squad
+
   defstruct [:id, :audit, :name, :squads]
 
-  @type t :: %KanbanVisionApi.Domain.Tribe{
+  @type t :: %__MODULE__{
           id: String.t(),
-          audit: KanbanVisionApi.Domain.Audit.t(),
+          audit: Audit.t(),
           name: String.t(),
-          squads: [KanbanVisionApi.Domain.Squad.t()]
+          squads: [Squad.t()]
         }
 
-  def new(name, squads \\ [], id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new()) do
-    %KanbanVisionApi.Domain.Tribe{
+  def new(name, squads \\ [], id \\ UUID.uuid4(), audit \\ Audit.new()) do
+    %__MODULE__{
       id: id,
       audit: audit,
       name: name,

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/worker.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/worker.ex
@@ -1,17 +1,20 @@
 defmodule KanbanVisionApi.Domain.Worker do
   @moduledoc false
 
+  alias KanbanVisionApi.Domain.Ability
+  alias KanbanVisionApi.Domain.Audit
+
   defstruct [:id, :audit, :name, :abilities]
 
-  @type t :: %KanbanVisionApi.Domain.Worker{
+  @type t :: %__MODULE__{
           id: String.t(),
-          audit: KanbanVisionApi.Domain.Audit.t(),
+          audit: Audit.t(),
           name: String.t(),
-          abilities: [KanbanVisionApi.Domain.Ability.t()]
+          abilities: [Ability.t()]
         }
 
-  def new(name, abilities \\ [], id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new()) do
-    %KanbanVisionApi.Domain.Worker{
+  def new(name, abilities \\ [], id \\ UUID.uuid4(), audit \\ Audit.new()) do
+    %__MODULE__{
       id: id,
       audit: audit,
       name: name,

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/worker.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/worker.ex
@@ -7,17 +7,15 @@ defmodule KanbanVisionApi.Domain.Worker do
           id: String.t(),
           audit: KanbanVisionApi.Domain.Audit.t(),
           name: String.t(),
-          abilities: List.t()
+          abilities: [KanbanVisionApi.Domain.Ability.t()]
         }
 
   def new(name, abilities \\ [], id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new()) do
-    initial_state = %KanbanVisionApi.Domain.Worker{
+    %KanbanVisionApi.Domain.Worker{
       id: id,
       audit: audit,
       name: name,
       abilities: abilities
     }
-
-    initial_state
   end
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/workflow.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/workflow.ex
@@ -6,16 +6,14 @@ defmodule KanbanVisionApi.Domain.Workflow do
   @type t :: %KanbanVisionApi.Domain.Workflow{
           id: String.t(),
           audit: KanbanVisionApi.Domain.Audit.t(),
-          steps: List.t()
+          steps: [KanbanVisionApi.Domain.Step.t()]
         }
 
   def new(steps \\ [], id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new()) do
-    initial_state = %KanbanVisionApi.Domain.Workflow{
+    %KanbanVisionApi.Domain.Workflow{
       id: id,
       audit: audit,
       steps: steps
     }
-
-    initial_state
   end
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/workflow.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/workflow.ex
@@ -1,16 +1,19 @@
 defmodule KanbanVisionApi.Domain.Workflow do
   @moduledoc false
 
+  alias KanbanVisionApi.Domain.Audit
+  alias KanbanVisionApi.Domain.Step
+
   defstruct [:id, :audit, :steps]
 
-  @type t :: %KanbanVisionApi.Domain.Workflow{
+  @type t :: %__MODULE__{
           id: String.t(),
-          audit: KanbanVisionApi.Domain.Audit.t(),
-          steps: [KanbanVisionApi.Domain.Step.t()]
+          audit: Audit.t(),
+          steps: [Step.t()]
         }
 
-  def new(steps \\ [], id \\ UUID.uuid4(), audit \\ KanbanVisionApi.Domain.Audit.new()) do
-    %KanbanVisionApi.Domain.Workflow{
+  def new(steps \\ [], id \\ UUID.uuid4(), audit \\ Audit.new()) do
+    %__MODULE__{
       id: id,
       audit: audit,
       steps: steps

--- a/apps/persistence/lib/kanban_vision_api/agent/boards.ex
+++ b/apps/persistence/lib/kanban_vision_api/agent/boards.ex
@@ -7,13 +7,13 @@ defmodule KanbanVisionApi.Agent.Boards do
 
   defstruct [:id, :boards]
 
-  @type t :: %KanbanVisionApi.Agent.Boards{
+  @type t :: %__MODULE__{
           id: String.t(),
-          boards: Map.t()
+          boards: map()
         }
 
   def new(boards \\ %{}, id \\ UUID.uuid4()) do
-    %KanbanVisionApi.Agent.Boards{
+    %__MODULE__{
       id: id,
       boards: boards
     }
@@ -21,8 +21,8 @@ defmodule KanbanVisionApi.Agent.Boards do
 
   # Client
 
-  @spec start_link(KanbanVisionApi.Agent.Boards.t()) :: Agent.on_start()
-  def start_link(default \\ KanbanVisionApi.Agent.Boards.new()) do
+  @spec start_link(t()) :: Agent.on_start()
+  def start_link(default \\ __MODULE__.new()) do
     Agent.start_link(fn -> default end)
   end
 

--- a/apps/persistence/lib/kanban_vision_api/agent/organizations.ex
+++ b/apps/persistence/lib/kanban_vision_api/agent/organizations.ex
@@ -7,13 +7,13 @@ defmodule KanbanVisionApi.Agent.Organizations do
 
   defstruct [:id, :organizations]
 
-  @type t :: %KanbanVisionApi.Agent.Organizations{
+  @type t :: %__MODULE__{
           id: String.t(),
-          organizations: Map.t()
+          organizations: map()
         }
 
   def new(organizations \\ %{}, id \\ UUID.uuid4()) do
-    %KanbanVisionApi.Agent.Organizations{
+    %__MODULE__{
       id: id,
       organizations: organizations
     }
@@ -21,8 +21,8 @@ defmodule KanbanVisionApi.Agent.Organizations do
 
   # Client
 
-  @spec start_link(KanbanVisionApi.Agent.Organizations.t()) :: Agent.on_start()
-  def start_link(default \\ KanbanVisionApi.Agent.Organizations.new()) do
+  @spec start_link(t()) :: Agent.on_start()
+  def start_link(default \\ __MODULE__.new()) do
     Agent.start_link(fn -> default end)
   end
 

--- a/apps/persistence/lib/kanban_vision_api/agent/simulations.ex
+++ b/apps/persistence/lib/kanban_vision_api/agent/simulations.ex
@@ -7,13 +7,13 @@ defmodule KanbanVisionApi.Agent.Simulations do
 
   defstruct [:id, :simulations_by_organization]
 
-  @type t :: %KanbanVisionApi.Agent.Simulations{
+  @type t :: %__MODULE__{
           id: String.t(),
-          simulations_by_organization: Map.t()
+          simulations_by_organization: map()
         }
 
   def new(simulations_by_organization \\ %{}, id \\ UUID.uuid4()) do
-    %KanbanVisionApi.Agent.Simulations{
+    %__MODULE__{
       id: id,
       simulations_by_organization: simulations_by_organization
     }
@@ -21,8 +21,8 @@ defmodule KanbanVisionApi.Agent.Simulations do
 
   # Client
 
-  @spec start_link(KanbanVisionApi.Agent.Simulations.t()) :: Agent.on_start()
-  def start_link(default \\ KanbanVisionApi.Agent.Simulations.new()) do
+  @spec start_link(t()) :: Agent.on_start()
+  def start_link(default \\ __MODULE__.new()) do
     Agent.start_link(fn -> default end)
   end
 

--- a/apps/persistence/test/kanban_vision_api/agent/boards_test.exs
+++ b/apps/persistence/test/kanban_vision_api/agent/boards_test.exs
@@ -2,6 +2,10 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
   use ExUnit.Case, async: true
   doctest KanbanVisionApi.Agent.Boards
 
+  alias KanbanVisionApi.Agent.Boards
+  alias KanbanVisionApi.Domain.Board
+  alias KanbanVisionApi.Domain.Workflow
+
   describe "When start the system with empty state" do
     setup [:prepare_empty_context]
 
@@ -12,7 +16,7 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
            boards: _boards
          } = _context do
       template = %{}
-      assert KanbanVisionApi.Agent.Boards.get_all(pid) == template
+      assert Boards.get_all(pid) == template
     end
 
     @tag :domain_boards
@@ -22,7 +26,7 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
            boards: _boards
          } = _context do
       template = {:error, "Boards by simulation_id: nada not found"}
-      assert KanbanVisionApi.Agent.Boards.get_all_by_simulation_id(pid, "nada") == template
+      assert Boards.get_all_by_simulation_id(pid, "nada") == template
     end
 
     @tag :domain_boards
@@ -30,9 +34,9 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
          %{
            actor_pid: pid
          } = _context do
-      board = KanbanVisionApi.Domain.Board.new("Dev Board", "sim-123")
-      assert {:ok, ^board} = KanbanVisionApi.Agent.Boards.add(pid, board)
-      assert %{} = KanbanVisionApi.Agent.Boards.get_all(pid)
+      board = Board.new("Dev Board", "sim-123")
+      assert {:ok, ^board} = Boards.add(pid, board)
+      assert %{} = Boards.get_all(pid)
     end
 
     @tag :domain_boards
@@ -40,11 +44,11 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
          %{
            actor_pid: pid
          } = _context do
-      board = KanbanVisionApi.Domain.Board.new("Dev Board", "sim-123")
-      assert {:ok, ^board} = KanbanVisionApi.Agent.Boards.add(pid, board)
+      board = Board.new("Dev Board", "sim-123")
+      assert {:ok, ^board} = Boards.add(pid, board)
 
-      duplicate = KanbanVisionApi.Domain.Board.new("Dev Board", "sim-123")
-      assert {:error, _msg} = KanbanVisionApi.Agent.Boards.add(pid, duplicate)
+      duplicate = Board.new("Dev Board", "sim-123")
+      assert {:error, _msg} = Boards.add(pid, duplicate)
     end
   end
 
@@ -58,7 +62,7 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
            board: board
          } = _context do
       assert {:ok, boards} =
-               KanbanVisionApi.Agent.Boards.get_all_by_simulation_id(pid, board.simulation_id)
+               Boards.get_all_by_simulation_id(pid, board.simulation_id)
 
       assert length(boards) == 1
     end
@@ -69,9 +73,9 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
            actor_pid: pid,
            board: board
          } = _context do
-      new_board = KanbanVisionApi.Domain.Board.new("QA Board", board.simulation_id)
-      assert {:ok, ^new_board} = KanbanVisionApi.Agent.Boards.add(pid, new_board)
-      assert 2 = map_size(KanbanVisionApi.Agent.Boards.get_all(pid))
+      new_board = Board.new("QA Board", board.simulation_id)
+      assert {:ok, ^new_board} = Boards.add(pid, new_board)
+      assert 2 = map_size(Boards.get_all(pid))
     end
 
     @tag :domain_boards
@@ -80,14 +84,14 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
            actor_pid: pid
          } = _context do
       assert {:error, _msg} =
-               KanbanVisionApi.Agent.Boards.get_all_by_simulation_id(pid, "unknown")
+               Boards.get_all_by_simulation_id(pid, "unknown")
     end
   end
 
   defp prepare_empty_context(_context) do
-    boards_domain = KanbanVisionApi.Agent.Boards.new()
-    workflow_domain = KanbanVisionApi.Domain.Workflow.new()
-    {:ok, pid} = KanbanVisionApi.Agent.Boards.start_link(boards_domain)
+    boards_domain = Boards.new()
+    workflow_domain = Workflow.new()
+    {:ok, pid} = Boards.start_link(boards_domain)
 
     [
       actor_pid: pid,
@@ -97,9 +101,9 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
   end
 
   defp prepare_context_with_boards(_context) do
-    board = KanbanVisionApi.Domain.Board.new("Dev Board", "sim-123")
-    boards_domain = KanbanVisionApi.Agent.Boards.new(%{board.id => board})
-    {:ok, pid} = KanbanVisionApi.Agent.Boards.start_link(boards_domain)
+    board = Board.new("Dev Board", "sim-123")
+    boards_domain = Boards.new(%{board.id => board})
+    {:ok, pid} = Boards.start_link(boards_domain)
 
     [
       actor_pid: pid,

--- a/apps/persistence/test/kanban_vision_api/agent/organizations_test.exs
+++ b/apps/persistence/test/kanban_vision_api/agent/organizations_test.exs
@@ -2,6 +2,9 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
   use ExUnit.Case, async: true
   doctest KanbanVisionApi.Agent.Organizations
 
+  alias KanbanVisionApi.Agent.Organizations
+  alias KanbanVisionApi.Domain.Organization
+
   describe "When start the system with empty state" do
     setup [:prepare_empty_context]
 
@@ -12,7 +15,7 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
            organizations: _organizations
          } = _context do
       template = %{}
-      assert KanbanVisionApi.Agent.Organizations.get_all(pid) == template
+      assert Organizations.get_all(pid) == template
     end
 
     @tag :domain_organizations
@@ -21,8 +24,8 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
            actor_pid: pid,
            organizations: _organizations
          } = _context do
-      domain = KanbanVisionApi.Domain.Organization.new("ExampleOrg")
-      assert KanbanVisionApi.Agent.Organizations.add(pid, domain) == {:ok, domain}
+      domain = Organization.new("ExampleOrg")
+      assert Organizations.add(pid, domain) == {:ok, domain}
     end
 
     @tag :domain_organizations
@@ -31,9 +34,9 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
            actor_pid: pid,
            organizations: _organizations
          } = _context do
-      domain = KanbanVisionApi.Domain.Organization.new("ExampleOrg")
-      assert KanbanVisionApi.Agent.Organizations.add(pid, domain) == {:ok, domain}
-      assert KanbanVisionApi.Agent.Organizations.delete(pid, domain.id) == {:ok, domain}
+      domain = Organization.new("ExampleOrg")
+      assert Organizations.add(pid, domain) == {:ok, domain}
+      assert Organizations.delete(pid, domain.id) == {:ok, domain}
     end
 
     @tag :domain_organizations
@@ -43,7 +46,7 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
            organizations: _organizations
          } = _context do
       template = {:error, "Organization with id: nada not found"}
-      assert KanbanVisionApi.Agent.Organizations.delete(pid, :nada) == template
+      assert Organizations.delete(pid, :nada) == template
     end
   end
 
@@ -59,7 +62,7 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
          } = _context do
       template = %{my_domain.id => my_domain}
 
-      assert KanbanVisionApi.Agent.Organizations.get_all(pid) == template
+      assert Organizations.get_all(pid) == template
     end
 
     @tag :domain_organizations
@@ -69,7 +72,7 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
            organizations: _organizations,
            domain: domain
          } = _context do
-      assert KanbanVisionApi.Agent.Organizations.get_by_id(pid, domain.id) == {:ok, domain}
+      assert Organizations.get_by_id(pid, domain.id) == {:ok, domain}
     end
 
     @tag :domain_organizations
@@ -79,7 +82,7 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
            organizations: _organizations,
            domain: domain
          } = _context do
-      assert KanbanVisionApi.Agent.Organizations.get_by_name(pid, domain.name) == {:ok, [domain]}
+      assert Organizations.get_by_name(pid, domain.name) == {:ok, [domain]}
     end
 
     @tag :domain_organizations
@@ -90,7 +93,7 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
            domain: _domain
          } = _context do
       template = {:error, "Organization with id: nada not found"}
-      assert KanbanVisionApi.Agent.Organizations.get_by_id(pid, :nada) == template
+      assert Organizations.get_by_id(pid, :nada) == template
     end
 
     @tag :domain_organizations
@@ -101,7 +104,7 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
            domain: _domain
          } = _context do
       template = {:error, "Organization with name: Invalid Name not found"}
-      assert KanbanVisionApi.Agent.Organizations.get_by_name(pid, "Invalid Name") == template
+      assert Organizations.get_by_name(pid, "Invalid Name") == template
     end
 
     @tag :domain_organizations
@@ -112,13 +115,13 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
            domain: domain
          } = _context do
       template = {:error, "Organization with name: ExampleOrg already exist"}
-      assert KanbanVisionApi.Agent.Organizations.add(pid, domain) == template
+      assert Organizations.add(pid, domain) == template
     end
   end
 
   defp prepare_empty_context(_context) do
-    organizations_domain = KanbanVisionApi.Agent.Organizations.new()
-    {:ok, pid} = KanbanVisionApi.Agent.Organizations.start_link(organizations_domain)
+    organizations_domain = Organizations.new()
+    {:ok, pid} = Organizations.start_link(organizations_domain)
 
     [
       actor_pid: pid,
@@ -127,12 +130,12 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
   end
 
   defp prepare_context_with_default_organization(_context) do
-    organization_domain = KanbanVisionApi.Domain.Organization.new("ExampleOrg")
+    organization_domain = Organization.new("ExampleOrg")
 
     initial_state =
-      KanbanVisionApi.Agent.Organizations.new(%{organization_domain.id => organization_domain})
+      Organizations.new(%{organization_domain.id => organization_domain})
 
-    {:ok, pid} = KanbanVisionApi.Agent.Organizations.start_link(initial_state)
+    {:ok, pid} = Organizations.start_link(initial_state)
 
     [
       actor_pid: pid,

--- a/apps/persistence/test/kanban_vision_api/agent/simulation_repository_contract_test.exs
+++ b/apps/persistence/test/kanban_vision_api/agent/simulation_repository_contract_test.exs
@@ -41,7 +41,6 @@ defmodule KanbanVisionApi.Agent.SimulationRepositoryContractTest do
       sim = Simulation.new("FindableSim", "Description", org_id)
       {:ok, created} = Simulations.add(pid, sim)
 
-      # Agent returns {:ok, simulation} not {:ok, [simulation]}
       assert {:ok, ^created} =
                Simulations.get_by_organization_id_and_simulation_name(pid, org_id, "FindableSim")
 

--- a/apps/persistence/test/kanban_vision_api/agent/simulations_test.exs
+++ b/apps/persistence/test/kanban_vision_api/agent/simulations_test.exs
@@ -2,6 +2,10 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
   use ExUnit.Case, async: true
   doctest KanbanVisionApi.Agent.Simulations
 
+  alias KanbanVisionApi.Agent.Simulations
+  alias KanbanVisionApi.Domain.Organization
+  alias KanbanVisionApi.Domain.Simulation
+
   describe "When start the system with empty state" do
     setup [:prepare_empty_context]
 
@@ -14,7 +18,7 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
          } = _context do
       template = %{}
 
-      assert KanbanVisionApi.Agent.Simulations.get_all(pid) == template
+      assert Simulations.get_all(pid) == template
     end
 
     @tag :domain_smulations
@@ -25,13 +29,13 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
            organization: organization
          } = _context do
       simulation_domain =
-        KanbanVisionApi.Domain.Simulation.new(
+        Simulation.new(
           "ExampleSimulation",
           "ExampleSimulationDescription",
           organization.id
         )
 
-      assert KanbanVisionApi.Agent.Simulations.add(pid, simulation_domain) ==
+      assert Simulations.add(pid, simulation_domain) ==
                {:ok, simulation_domain}
     end
   end
@@ -49,7 +53,7 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
          } = _context do
       template = %{organization.id => %{simulation.id => simulation}}
 
-      assert KanbanVisionApi.Agent.Simulations.get_all(pid) == template
+      assert Simulations.get_all(pid) == template
     end
 
     @tag :domain_smulations
@@ -61,19 +65,19 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
            organization: organization
          } = _context do
       new_simulation =
-        KanbanVisionApi.Domain.Simulation.new(
+        Simulation.new(
           "AnotherExampleOfSimulation",
           "AnotherExampleOfSimulationDescription",
           organization.id
         )
 
-      assert KanbanVisionApi.Agent.Simulations.add(pid, new_simulation) == {:ok, new_simulation}
+      assert Simulations.add(pid, new_simulation) == {:ok, new_simulation}
 
       template = %{
         organization.id => %{new_simulation.id => new_simulation, simulation.id => simulation}
       }
 
-      assert KanbanVisionApi.Agent.Simulations.get_all(pid) == template
+      assert Simulations.get_all(pid) == template
     end
 
     @tag :domain_smulations
@@ -84,7 +88,7 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
            simulation: simulation,
            organization: _organization
          } = _context do
-      assert KanbanVisionApi.Agent.Simulations.add(pid, simulation) == {
+      assert Simulations.add(pid, simulation) == {
                :error,
                """
                Simulation with organization_id: #{simulation.organization_id}
@@ -102,7 +106,7 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
          } = _context do
       template = {:error, "Simulation with organization id: INVALID not found"}
 
-      assert KanbanVisionApi.Agent.Simulations.get_by_organization_id_and_simulation_name(
+      assert Simulations.get_by_organization_id_and_simulation_name(
                pid,
                "INVALID",
                "Simulation Name"
@@ -117,7 +121,7 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
          } = _context do
       template = {:error, "Simulation with name: Missing Simulation not found"}
 
-      assert KanbanVisionApi.Agent.Simulations.get_by_organization_id_and_simulation_name(
+      assert Simulations.get_by_organization_id_and_simulation_name(
                pid,
                organization.id,
                "Missing Simulation"
@@ -136,7 +140,7 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
          } = _context do
       template = {:error, "Simulation with organization id: #{organization.id} not found"}
 
-      assert KanbanVisionApi.Agent.Simulations.get_by_organization_id_and_simulation_name(
+      assert Simulations.get_by_organization_id_and_simulation_name(
                pid,
                organization.id,
                "Any Simulation"
@@ -145,9 +149,9 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
   end
 
   defp prepare_empty_context(_context) do
-    simulations_domain = KanbanVisionApi.Agent.Simulations.new()
-    organization_domain = KanbanVisionApi.Domain.Organization.new("ExampleOrg")
-    {:ok, pid} = KanbanVisionApi.Agent.Simulations.start_link(simulations_domain)
+    simulations_domain = Simulations.new()
+    organization_domain = Organization.new("ExampleOrg")
+    {:ok, pid} = Simulations.start_link(simulations_domain)
 
     [
       actor_pid: pid,
@@ -157,10 +161,10 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
   end
 
   defp prepare_context_with_data(_context) do
-    organization_domain = KanbanVisionApi.Domain.Organization.new("ExampleOrg")
+    organization_domain = Organization.new("ExampleOrg")
 
     simulation_domain =
-      KanbanVisionApi.Domain.Simulation.new(
+      Simulation.new(
         "ExampleSimulation",
         "ExampleSimulationDescription",
         organization_domain.id
@@ -170,9 +174,9 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
       organization_domain.id => %{simulation_domain.id => simulation_domain}
     }
 
-    simulations_domain = KanbanVisionApi.Agent.Simulations.new(simulations_by_organization)
+    simulations_domain = Simulations.new(simulations_by_organization)
 
-    {:ok, pid} = KanbanVisionApi.Agent.Simulations.start_link(simulations_domain)
+    {:ok, pid} = Simulations.start_link(simulations_domain)
 
     [
       actor_pid: pid,
@@ -183,9 +187,9 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
   end
 
   defp prepare_context_with_empty_org(_context) do
-    organization_domain = KanbanVisionApi.Domain.Organization.new("ExampleOrg")
-    simulations_domain = KanbanVisionApi.Agent.Simulations.new(%{organization_domain.id => %{}})
-    {:ok, pid} = KanbanVisionApi.Agent.Simulations.start_link(simulations_domain)
+    organization_domain = Organization.new("ExampleOrg")
+    simulations_domain = Simulations.new(%{organization_domain.id => %{}})
+    {:ok, pid} = Simulations.start_link(simulations_domain)
 
     [
       actor_pid: pid,

--- a/apps/usecase/lib/kanban_vision_api/usecase/event_emitter.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/event_emitter.ex
@@ -1,0 +1,17 @@
+defmodule KanbanVisionApi.Usecase.EventEmitter do
+  @moduledoc """
+  Shared telemetry event emission for use cases.
+
+  Wraps :telemetry.execute/3 calls with a consistent event namespace
+  and metadata structure across all use cases.
+  """
+
+  @spec emit(atom(), atom(), map(), String.t()) :: :ok
+  def emit(context, event_type, metadata, correlation_id) do
+    :telemetry.execute(
+      [:kanban_vision_api, context, event_type],
+      %{count: 1},
+      Map.put(metadata, :correlation_id, correlation_id)
+    )
+  end
+end

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_all_organizations.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_all_organizations.ex
@@ -7,17 +7,18 @@ defmodule KanbanVisionApi.Usecase.Organizations.GetAllOrganizations do
 
   require Logger
 
-  alias KanbanVisionApi.Agent.Organizations, as: OrganizationRepository
+  @default_repository KanbanVisionApi.Agent.Organizations
 
   @type result :: {:ok, map()}
 
   @spec execute(pid(), keyword()) :: result()
   def execute(repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
+    repository = Keyword.get(opts, :repository, @default_repository)
 
     Logger.debug("Retrieving all organizations", correlation_id: correlation_id)
 
-    organizations = OrganizationRepository.get_all(repository_pid)
+    organizations = repository.get_all(repository_pid)
 
     Logger.debug("All organizations retrieved",
       correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_id.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_id.ex
@@ -8,21 +8,23 @@ defmodule KanbanVisionApi.Usecase.Organizations.GetOrganizationById do
   require Logger
 
   alias KanbanVisionApi.Domain.Organization
-  alias KanbanVisionApi.Agent.Organizations, as: OrganizationRepository
   alias KanbanVisionApi.Usecase.Organization.GetOrganizationByIdQuery
+
+  @default_repository KanbanVisionApi.Agent.Organizations
 
   @type result :: {:ok, Organization.t()} | {:error, String.t()}
 
   @spec execute(GetOrganizationByIdQuery.t(), pid(), keyword()) :: result()
   def execute(%GetOrganizationByIdQuery{} = query, repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
+    repository = Keyword.get(opts, :repository, @default_repository)
 
     Logger.debug("Retrieving organization by ID",
       correlation_id: correlation_id,
       organization_id: query.id
     )
 
-    result = OrganizationRepository.get_by_id(repository_pid, query.id)
+    result = repository.get_by_id(repository_pid, query.id)
 
     case result do
       {:ok, org} ->

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_name.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_name.ex
@@ -7,21 +7,23 @@ defmodule KanbanVisionApi.Usecase.Organizations.GetOrganizationByName do
 
   require Logger
 
-  alias KanbanVisionApi.Agent.Organizations, as: OrganizationRepository
   alias KanbanVisionApi.Usecase.Organization.GetOrganizationByNameQuery
+
+  @default_repository KanbanVisionApi.Agent.Organizations
 
   @type result :: {:ok, list()} | {:error, String.t()}
 
   @spec execute(GetOrganizationByNameQuery.t(), pid(), keyword()) :: result()
   def execute(%GetOrganizationByNameQuery{} = query, repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
+    repository = Keyword.get(opts, :repository, @default_repository)
 
     Logger.debug("Retrieving organizations by name",
       correlation_id: correlation_id,
       organization_name: query.name
     )
 
-    result = OrganizationRepository.get_by_name(repository_pid, query.name)
+    result = repository.get_by_name(repository_pid, query.name)
 
     case result do
       {:ok, orgs} ->

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulation.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulation.ex
@@ -8,12 +8,13 @@ defmodule KanbanVisionApi.Usecase.Simulation do
 
   use GenServer
 
-  alias KanbanVisionApi.Agent.Simulations
   alias KanbanVisionApi.Usecase.Simulation.CreateSimulationCommand
   alias KanbanVisionApi.Usecase.Simulation.GetSimulationByOrgAndNameQuery
   alias KanbanVisionApi.Usecase.Simulations.CreateSimulation
   alias KanbanVisionApi.Usecase.Simulations.GetAllSimulations
   alias KanbanVisionApi.Usecase.Simulations.GetSimulationByOrgAndName
+
+  @default_repository KanbanVisionApi.Agent.Simulations
 
   # Client API
 
@@ -34,26 +35,33 @@ defmodule KanbanVisionApi.Usecase.Simulation do
   # Server — delegates to Use Cases
 
   @impl true
-  def init(_opts) do
-    {:ok, agent_pid} = Simulations.start_link()
-    {:ok, %{repository_pid: agent_pid}}
+  def init(opts) do
+    repository = Keyword.get(opts, :repository, @default_repository)
+    {:ok, agent_pid} = repository.start_link()
+    {:ok, %{repository_pid: agent_pid, repository: repository}}
   end
 
   @impl true
   def handle_call({:get_all, opts}, _from, state) do
-    result = GetAllSimulations.execute(state.repository_pid, opts)
+    result = GetAllSimulations.execute(state.repository_pid, enrich_opts(opts, state))
     {:reply, result, state}
   end
 
   @impl true
   def handle_call({:add, cmd, opts}, _from, state) do
-    result = CreateSimulation.execute(cmd, state.repository_pid, opts)
+    result = CreateSimulation.execute(cmd, state.repository_pid, enrich_opts(opts, state))
     {:reply, result, state}
   end
 
   @impl true
   def handle_call({:get_by_org_and_name, query, opts}, _from, state) do
-    result = GetSimulationByOrgAndName.execute(query, state.repository_pid, opts)
+    result =
+      GetSimulationByOrgAndName.execute(query, state.repository_pid, enrich_opts(opts, state))
+
     {:reply, result, state}
+  end
+
+  defp enrich_opts(opts, state) do
+    Keyword.put_new(opts, :repository, state.repository)
   end
 end

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulations/get_all_simulations.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulations/get_all_simulations.ex
@@ -7,17 +7,18 @@ defmodule KanbanVisionApi.Usecase.Simulations.GetAllSimulations do
 
   require Logger
 
-  alias KanbanVisionApi.Agent.Simulations, as: SimulationRepository
+  @default_repository KanbanVisionApi.Agent.Simulations
 
   @type result :: {:ok, map()}
 
   @spec execute(pid(), keyword()) :: result()
   def execute(repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
+    repository = Keyword.get(opts, :repository, @default_repository)
 
     Logger.debug("Retrieving all simulations", correlation_id: correlation_id)
 
-    simulations = SimulationRepository.get_all(repository_pid)
+    simulations = repository.get_all(repository_pid)
 
     Logger.debug("All simulations retrieved",
       correlation_id: correlation_id,

--- a/apps/usecase/mix.exs
+++ b/apps/usecase/mix.exs
@@ -30,7 +30,8 @@ defmodule Usecase.MixProject do
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
       {:kanban_domain, in_umbrella: true},
-      {:persistence, in_umbrella: true}
+      {:persistence, in_umbrella: true},
+      {:telemetry, "~> 1.0"}
     ]
   end
 end

--- a/apps/usecase/test/kanban_vision_api/usecase/organization_test.exs
+++ b/apps/usecase/test/kanban_vision_api/usecase/organization_test.exs
@@ -64,7 +64,7 @@ defmodule KanbanVisionApi.Usecase.OrganizationTest do
       assert {:error, _} = Organization.add(pid, cmd2)
     end
 
-    test "should reject invalid command", %{pid: pid} do
+    test "should reject invalid command", %{pid: _pid} do
       assert {:error, :invalid_name} = CreateOrganizationCommand.new("")
       assert {:error, :invalid_name} = CreateOrganizationCommand.new(nil)
     end

--- a/apps/usecase/test/kanban_vision_api/usecase/simulation_test.exs
+++ b/apps/usecase/test/kanban_vision_api/usecase/simulation_test.exs
@@ -1,6 +1,7 @@
 defmodule KanbanVisionApi.Usecase.SimulationTest do
   use ExUnit.Case, async: true
 
+  alias KanbanVisionApi.Domain.Organization
   alias KanbanVisionApi.Usecase.Simulation
   alias KanbanVisionApi.Usecase.Simulation.CreateSimulationCommand
   alias KanbanVisionApi.Usecase.Simulation.GetSimulationByOrgAndNameQuery
@@ -13,7 +14,7 @@ defmodule KanbanVisionApi.Usecase.SimulationTest do
     end
 
     test "should add a new simulation via command", %{pid: pid} do
-      org = KanbanVisionApi.Domain.Organization.new("TestOrg")
+      org = Organization.new("TestOrg")
 
       {:ok, cmd} = CreateSimulationCommand.new("TestSim", org.id, "Description")
 
@@ -23,7 +24,7 @@ defmodule KanbanVisionApi.Usecase.SimulationTest do
     end
 
     test "should find simulation by org and name via query", %{pid: pid} do
-      org = KanbanVisionApi.Domain.Organization.new("TestOrg")
+      org = Organization.new("TestOrg")
 
       {:ok, cmd} = CreateSimulationCommand.new("TestSim", org.id, "Description")
       {:ok, sim} = Simulation.add(pid, cmd)

--- a/apps/usecase/test/kanban_vision_api/usecase/simulation_test.exs
+++ b/apps/usecase/test/kanban_vision_api/usecase/simulation_test.exs
@@ -29,8 +29,7 @@ defmodule KanbanVisionApi.Usecase.SimulationTest do
       {:ok, sim} = Simulation.add(pid, cmd)
 
       {:ok, query} = GetSimulationByOrgAndNameQuery.new(org.id, "TestSim")
-      # The result is a list, not a single simulation
-      assert {:ok, [^sim]} = Simulation.get_by_org_and_name(pid, query)
+      assert {:ok, ^sim} = Simulation.get_by_org_and_name(pid, query)
     end
 
     test "should return error for non-existent simulation", %{pid: pid} do
@@ -38,7 +37,7 @@ defmodule KanbanVisionApi.Usecase.SimulationTest do
       assert {:error, _} = Simulation.get_by_org_and_name(pid, query)
     end
 
-    test "should reject invalid command", %{pid: pid} do
+    test "should reject invalid command", %{pid: _pid} do
       assert {:error, :invalid_name} = CreateSimulationCommand.new("", "org-id")
 
       assert {:error, :invalid_organization_id} =

--- a/docs/skills/Elixir.md
+++ b/docs/skills/Elixir.md
@@ -1,0 +1,1193 @@
+---
+name: elixir
+description: >
+  Use when working with Elixir code — writing modules, functions, tests, mix tasks,
+  templates, logging, or any Elixir/OTP project. Covers Elixir v1.19.5 (stable),
+  including standard library (Kernel), EEx, ExUnit, IEx, Logger, and Mix.
+---
+
+# Elixir Development Skill
+
+Reference for Elixir v1.19.5 | OTP 26/27/28
+
+---
+
+## 1. Projeto e Estrutura (Mix)
+
+### Criar novo projeto
+```bash
+mix new my_app               # aplicação simples
+mix new my_app --sup         # com Supervisor (OTP)
+mix new my_app --umbrella    # projeto umbrella (multi-app)
+```
+
+### Estrutura padrão
+```
+my_app/
+├── lib/
+│   └── my_app.ex            # módulo principal
+├── test/
+│   ├── test_helper.exs      # inicializa ExUnit
+│   └── my_app_test.exs      # testes
+├── config/
+│   ├── config.exs           # configuração build-time
+│   ├── dev.exs
+│   ├── test.exs
+│   ├── prod.exs
+│   └── runtime.exs          # configuração runtime (releases)
+└── mix.exs                  # definição do projeto
+```
+
+### mix.exs completo
+```elixir
+defmodule MyApp.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :my_app,
+      version: "0.1.0",
+      elixir: "~> 1.19",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      aliases: aliases(),
+      test_coverage: [tool: ExCoveralls]
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger],
+      mod: {MyApp.Application, []}
+    ]
+  end
+
+  defp deps do
+    [
+      {:jason, "~> 1.4"},
+      {:ecto_sql, "~> 3.10"},
+      {:ex_doc, "~> 0.31", only: :dev, runtime: false},
+      {:excoveralls, "~> 0.18", only: :test}
+    ]
+  end
+
+  defp aliases do
+    [
+      setup: ["deps.get", "ecto.setup"],
+      "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+      test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"]
+    ]
+  end
+end
+```
+
+### Comandos Mix essenciais
+```bash
+mix deps.get              # instala dependências
+mix deps.update --all     # atualiza todas as deps
+mix compile               # compila o projeto
+mix test                  # roda os testes
+mix test --only focus     # roda apenas testes com @tag focus
+mix test test/meu_test.exs:42  # roda teste na linha 42
+mix format                # formata código
+mix format --check-formatted  # verifica formatação (CI)
+mix credo                 # análise estática (requer dep credo)
+mix docs                  # gera documentação
+mix release               # cria release de produção
+MIX_ENV=prod mix compile  # compila em modo prod
+```
+
+### Ambientes Mix
+```bash
+MIX_ENV=dev   # padrão
+MIX_ENV=test  # usado por `mix test`
+MIX_ENV=prod  # produção
+```
+
+```elixir
+# Verificar ambiente em runtime
+Mix.env() #=> :dev | :test | :prod
+
+# Dep apenas para determinado ambiente
+{:dep_name, "~> x.y", only: [:dev, :test]}
+{:dep_name, "~> x.y", only: :test, runtime: false}
+```
+
+---
+
+## 2. Módulos e Funções (Kernel)
+
+### Definindo módulos
+```elixir
+defmodule MyApp.User do
+  @moduledoc """
+  Representa um usuário do sistema.
+  """
+
+  @type t :: %__MODULE__{
+    id: integer(),
+    name: String.t(),
+    email: String.t(),
+    active: boolean()
+  }
+
+  defstruct [:id, :name, :email, active: true]
+
+  @doc """
+  Cria um novo usuário.
+
+  ## Exemplos
+
+      iex> MyApp.User.new(1, "Alice", "alice@example.com")
+      %MyApp.User{id: 1, name: "Alice", email: "alice@example.com", active: true}
+  """
+  @spec new(integer(), String.t(), String.t()) :: t()
+  def new(id, name, email) do
+    %__MODULE__{id: id, name: name, email: email}
+  end
+
+  # Função privada
+  defp validate_email(email), do: String.contains?(email, "@")
+end
+```
+
+### Pattern matching em funções
+```elixir
+defmodule MyApp.Shape do
+  def area({:circle, r}),        do: :math.pi() * r * r
+  def area({:rectangle, w, h}),  do: w * h
+  def area({:triangle, b, h}),   do: b * h / 2
+
+  # Cláusula de fallback
+  def area(shape), do: {:error, "Unknown shape: #{inspect(shape)}"}
+end
+```
+
+### Guards
+```elixir
+defmodule MyApp.Validator do
+  # Guards built-in: is_integer, is_float, is_atom, is_binary,
+  #                  is_list, is_map, is_tuple, is_nil, is_boolean,
+  #                  is_function, is_pid, is_port, is_reference,
+  #                  is_number, is_struct, is_exception
+
+  def classify(n) when is_integer(n) and n > 0, do: :positive_integer
+  def classify(n) when is_integer(n) and n < 0, do: :negative_integer
+  def classify(0),                               do: :zero
+  def classify(n) when is_float(n),              do: :float
+  def classify(_),                               do: :other
+
+  # Definindo guard customizado com defguard
+  defguard is_adult(age) when is_integer(age) and age >= 18
+
+  def can_vote?(age) when is_adult(age), do: true
+  def can_vote?(_), do: false
+end
+```
+
+### Operador pipe `|>`
+```elixir
+# Sem pipe:
+String.trim(String.downcase(String.replace("  Hello World  ", " ", "_")))
+
+# Com pipe (legível, da esquerda para a direita):
+"  Hello World  "
+|> String.replace(" ", "_")
+|> String.downcase()
+|> String.trim()
+#=> "hello_world"
+
+# Pipeline de processamento real:
+users
+|> Enum.filter(& &1.active)
+|> Enum.map(& &1.email)
+|> Enum.sort()
+|> Enum.uniq()
+```
+
+### Closures e funções anônimas
+```elixir
+# Função anônima curta
+add = fn a, b -> a + b end
+add.(1, 2) #=> 3
+
+# Shorthand com &
+double = &(&1 * 2)
+double.(5) #=> 10
+
+multiply = &(&1 * &2)
+multiply.(3, 4) #=> 12
+
+# Capturando função nomeada
+to_string_fn = &Integer.to_string/1
+to_string_fn.(42) #=> "42"
+
+# Passando como argumento
+[1, 2, 3] |> Enum.map(&double.(&1))
+# ou mais idiomático:
+[1, 2, 3] |> Enum.map(&(&1 * 2))
+```
+
+---
+
+## 3. Tipos de Dados e Módulos da Stdlib
+
+### String
+```elixir
+# Strings são binários UTF-8
+"hello" <> " " <> "world"          #=> "hello world"
+String.upcase("hello")              #=> "HELLO"
+String.downcase("HELLO")            #=> "hello"
+String.length("héllo")             #=> 5 (caracteres Unicode)
+String.split("a,b,c", ",")         #=> ["a", "b", "c"]
+String.trim("  hello  ")           #=> "hello"
+String.replace("foo bar", "bar", "baz")  #=> "foo baz"
+String.contains?("hello", "ell")   #=> true
+String.starts_with?("hello", "he") #=> true
+String.ends_with?("hello", "lo")   #=> true
+String.to_integer("42")            #=> 42
+String.to_float("3.14")            #=> 3.14
+String.slice("hello", 1, 3)        #=> "ell"
+String.pad_leading("42", 5, "0")   #=> "00042"
+
+# Interpolação
+name = "Alice"
+"Hello, #{name}!"                  #=> "Hello, Alice!"
+"2 + 2 = #{2 + 2}"                #=> "2 + 2 = 4"
+```
+
+### Integer e Float
+```elixir
+Integer.to_string(255, 16)   #=> "FF"        (base 16)
+Integer.to_string(8, 2)      #=> "1000"      (base 2)
+Integer.parse("42")          #=> {42, ""}
+Integer.digits(123)          #=> [1, 2, 3]
+
+Float.round(3.14159, 2)      #=> 3.14
+Float.ceil(1.2)              #=> 2.0
+Float.floor(1.9)             #=> 1.0
+```
+
+### Atom
+```elixir
+:ok
+:error
+:hello
+true          # atom
+false         # atom
+nil           # atom
+
+is_atom(:ok)  #=> true
+Atom.to_string(:hello)  #=> "hello"
+String.to_atom("hello") #=> :hello  (cuidado: não usar com input externo)
+String.to_existing_atom("hello")  # mais seguro
+```
+
+### List
+```elixir
+list = [1, 2, 3, 4, 5]
+
+hd(list)          #=> 1
+tl(list)          #=> [2, 3, 4, 5]
+length(list)      #=> 5
+[0 | list]        #=> [0, 1, 2, 3, 4, 5]  (prepend, O(1))
+list ++ [6, 7]    #=> [1, 2, 3, 4, 5, 6, 7]
+list -- [2, 4]    #=> [1, 3, 5]
+
+List.first(list)  #=> 1
+List.last(list)   #=> 5
+List.flatten([[1, [2]], [3]])  #=> [1, 2, 3]
+List.zip([[1,2], [3,4]])      #=> [{1,3}, {2,4}]
+```
+
+### Keyword List
+```elixir
+# Lista de tuplas de 2 elementos com átomo como chave
+opts = [timeout: 5000, retry: 3, verbose: true]
+
+opts[:timeout]            #=> 5000
+Keyword.get(opts, :retry) #=> 3
+Keyword.put(opts, :debug, false)
+Keyword.merge(opts, [timeout: 3000])
+Keyword.keys(opts)        #=> [:timeout, :retry, :verbose]
+
+# Usado como opções em funções (convenção Elixir)
+def connect(host, port, opts \\ []) do
+  timeout = Keyword.get(opts, :timeout, 5000)
+  # ...
+end
+```
+
+### Map
+```elixir
+map = %{name: "Alice", age: 30, active: true}
+
+# Acesso
+map[:name]         #=> "Alice"
+map.name           #=> "Alice" (apenas para chaves atom)
+Map.get(map, :age) #=> 30
+Map.get(map, :email, "n/a")  #=> "n/a" (com default)
+
+# Atualização (imutável – retorna novo map)
+%{map | age: 31}          # atualiza chave existente
+Map.put(map, :email, "alice@example.com")
+Map.delete(map, :active)
+Map.merge(map, %{role: :admin})
+
+# Pattern matching em maps
+%{name: name, age: age} = map
+# name => "Alice", age => 30
+
+# Verificação
+Map.has_key?(map, :name)  #=> true
+Map.keys(map)             #=> [:active, :age, :name]
+Map.values(map)           #=> [true, 30, "Alice"]
+Map.to_list(map)          #=> [{:active, true}, {:age, 30}, {:name, "Alice"}]
+```
+
+### Tuple
+```elixir
+tuple = {:ok, "resultado", 42}
+
+elem(tuple, 0)                   #=> :ok
+elem(tuple, 1)                   #=> "resultado"
+tuple_size(tuple)                #=> 3
+put_elem(tuple, 2, 99)          #=> {:ok, "resultado", 99}
+
+# Convenção: usar para retorno com status
+{:ok, value}    # sucesso
+{:error, reason} # erro
+
+# Pattern matching
+case result do
+  {:ok, data}    -> process(data)
+  {:error, msg}  -> Logger.error(msg)
+end
+```
+
+### Enum (coleções eager)
+```elixir
+# Transformação
+Enum.map([1,2,3], &(&1 * 2))         #=> [2, 4, 6]
+Enum.filter([1,2,3,4], &(rem(&1,2) == 0))  #=> [2, 4]
+Enum.reject([1,2,3,4], &(rem(&1,2) == 0))  #=> [1, 3]
+Enum.reduce([1,2,3,4], 0, &+/2)      #=> 10
+Enum.flat_map([1,2,3], &[&1, &1*2])  #=> [1, 2, 2, 4, 3, 6]
+
+# Busca
+Enum.find([1,2,3], &(&1 > 2))        #=> 3
+Enum.find_index([1,2,3], &(&1 > 2))  #=> 2
+Enum.any?([1,2,3], &(&1 > 2))        #=> true
+Enum.all?([1,2,3], &(&1 > 0))        #=> true
+Enum.count([1,2,3], &(&1 > 1))       #=> 2
+
+# Ordenação
+Enum.sort([3,1,2])                    #=> [1, 2, 3]
+Enum.sort([3,1,2], :desc)             #=> [3, 2, 1]
+Enum.sort_by(users, & &1.name)
+Enum.min([3,1,2])                     #=> 1
+Enum.max([3,1,2])                     #=> 3
+Enum.min_max([3,1,2])                 #=> {1, 3}
+
+# Agrupamento e partição
+Enum.group_by([1,2,3,4], &(rem(&1,2) == 0))
+#=> %{false => [1, 3], true => [2, 4]}
+Enum.partition([1,2,3,4], &(rem(&1,2) == 0))
+#=> {[2, 4], [1, 3]}
+Enum.chunk_every([1,2,3,4,5], 2)
+#=> [[1, 2], [3, 4], [5]]
+Enum.zip([1,2,3], [:a, :b, :c])
+#=> [{1, :a}, {2, :b}, {3, :c}]
+Enum.with_index(["a","b","c"])
+#=> [{"a", 0}, {"b", 1}, {"c", 2}]
+
+# Redução avançada
+Enum.sum([1,2,3,4])                   #=> 10
+Enum.frequencies(["a","b","a","c"])   #=> %{"a" => 2, "b" => 1, "c" => 1}
+Enum.flat_map_reduce([1,2,3], 0, fn x, acc -> {[x, x], acc + x} end)
+```
+
+### Stream (coleções lazy)
+```elixir
+# Use Stream quando: grandes coleções ou pipelines com múltiplos passos
+# Avalia apenas quando necessário (com Enum no final)
+
+Stream.map(1..1_000_000, &(&1 * 2))
+|> Stream.filter(&(rem(&1, 3) == 0))
+|> Stream.take(10)
+|> Enum.to_list()
+
+# Leitura de arquivo linha a linha (sem carregar tudo na memória)
+File.stream!("big_file.txt")
+|> Stream.map(&String.trim/1)
+|> Stream.reject(&(&1 == ""))
+|> Enum.to_list()
+
+# Stream.cycle – lista infinita
+Stream.cycle([1,2,3]) |> Enum.take(7)  #=> [1,2,3,1,2,3,1]
+
+# Stream.iterate
+Stream.iterate(0, &(&1 + 1)) |> Enum.take(5)  #=> [0,1,2,3,4]
+
+# Stream.resource – IO externo
+Stream.resource(
+  fn -> File.open!("file.txt") end,
+  fn file ->
+    case IO.read(file, :line) do
+      :eof -> {:halt, file}
+      line -> {[line], file}
+    end
+  end,
+  fn file -> File.close(file) end
+)
+```
+
+---
+
+## 4. Controle de Fluxo
+
+### if / unless / cond / case
+```elixir
+# if / unless
+if condition do
+  "verdadeiro"
+else
+  "falso"
+end
+
+unless is_nil(value) do
+  process(value)
+end
+
+# Inline
+result = if valid?, do: "ok", else: "error"
+
+# cond – múltiplas condições
+cond do
+  x > 10  -> "grande"
+  x > 5   -> "médio"
+  x > 0   -> "pequeno"
+  true    -> "zero ou negativo"  # cláusula padrão
+end
+
+# case – pattern matching
+case http_response do
+  {:ok, 200, body}    -> process_body(body)
+  {:ok, 404, _}       -> {:error, :not_found}
+  {:ok, status, _}    -> {:error, {:unexpected_status, status}}
+  {:error, reason}    -> {:error, reason}
+end
+```
+
+### with – encadeamento de pattern matching
+```elixir
+# Ideal para fluxos "happy path" com possibilidade de erro
+with {:ok, user}  <- Users.get(user_id),
+     {:ok, order} <- Orders.create(user, params),
+     {:ok, email} <- Emails.send_confirmation(order) do
+  {:ok, %{user: user, order: order}}
+else
+  {:error, :not_found}   -> {:error, "Usuário não encontrado"}
+  {:error, changeset}    -> {:error, changeset_errors(changeset)}
+  error                  -> error
+end
+```
+
+### for – list comprehension
+```elixir
+# Básico
+for x <- 1..5, do: x * x
+#=> [1, 4, 9, 16, 25]
+
+# Com filtro (guard)
+for x <- 1..10, rem(x, 2) == 0, do: x
+#=> [2, 4, 6, 8, 10]
+
+# Múltiplos geradores (produto cartesiano)
+for x <- 1..3, y <- 1..3, x != y, do: {x, y}
+
+# Coletando em map
+for {key, val} <- [a: 1, b: 2, c: 3], into: %{}, do: {key, val * 10}
+#=> %{a: 10, b: 20, c: 30}
+
+# Coletando em string
+for byte <- 'hello', into: "", do: <<byte + 1>>
+```
+
+### try / rescue / catch / after
+```elixir
+try do
+  risky_operation()
+rescue
+  e in RuntimeError -> Logger.error("Runtime error: #{e.message}")
+  e in [ArgumentError, FunctionClauseError] -> handle_arg_error(e)
+  e -> reraise e, __STACKTRACE__  # re-levanta
+catch
+  :exit, reason -> handle_exit(reason)
+  :throw, value -> handle_throw(value)
+after
+  cleanup()  # sempre executado
+end
+
+# raise e rescue
+raise "something went wrong"
+raise ArgumentError, message: "invalid argument"
+raise MyCustomError, details: %{code: 404}
+
+# throw / catch (fluxo de controle, não erros)
+result = catch :throw do
+  Enum.each(list, fn item ->
+    if condition?(item), do: throw({:found, item})
+  end)
+  :not_found
+end
+```
+
+---
+
+## 5. Concorrência e OTP
+
+### Processos
+```elixir
+# Spawnar processo
+pid = spawn(fn -> IO.puts("olá do processo #{inspect(self())}") end)
+
+# Enviar e receber mensagens
+send(pid, {:hello, "mundo"})
+
+receive do
+  {:hello, msg} -> IO.puts("Recebi: #{msg}")
+  other         -> IO.puts("Mensagem inesperada: #{inspect(other)}")
+after
+  5000 -> IO.puts("Timeout!")
+end
+```
+
+### GenServer
+```elixir
+defmodule MyApp.Counter do
+  use GenServer
+
+  # --- API pública ---
+  def start_link(initial_value \\ 0) do
+    GenServer.start_link(__MODULE__, initial_value, name: __MODULE__)
+  end
+
+  def increment(amount \\ 1), do: GenServer.cast(__MODULE__, {:increment, amount})
+  def get_value,              do: GenServer.call(__MODULE__, :get_value)
+  def reset,                  do: GenServer.call(__MODULE__, :reset)
+
+  # --- Callbacks ---
+  @impl true
+  def init(initial_value), do: {:ok, initial_value}
+
+  @impl true
+  def handle_call(:get_value, _from, state), do: {:reply, state, state}
+  def handle_call(:reset, _from, _state),    do: {:reply, :ok, 0}
+
+  @impl true
+  def handle_cast({:increment, amount}, state), do: {:noreply, state + amount}
+end
+
+# Uso
+{:ok, _pid} = MyApp.Counter.start_link(10)
+MyApp.Counter.increment(5)
+MyApp.Counter.get_value()  #=> 15
+```
+
+### Supervisor
+```elixir
+defmodule MyApp.Application do
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    children = [
+      {MyApp.Counter, 0},
+      {MyApp.Worker, []},
+      {Task.Supervisor, name: MyApp.TaskSupervisor}
+    ]
+
+    opts = [strategy: :one_for_one, name: MyApp.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end
+
+# Estratégias de reinício:
+# :one_for_one   – reinicia só o filho falho
+# :one_for_all   – reinicia todos se um falhar
+# :rest_for_one  – reinicia o falho e todos iniciados depois dele
+```
+
+### Task
+```elixir
+# Execução assíncrona simples
+task = Task.async(fn -> heavy_computation() end)
+result = Task.await(task, 10_000)  # timeout em ms
+
+# Múltiplas tasks em paralelo
+tasks = Enum.map(urls, &Task.async(fn -> fetch(&1) end))
+results = Task.await_many(tasks, 30_000)
+
+# Task supervisionada (não derruba o chamador se falhar)
+Task.Supervisor.async_nolink(MyApp.TaskSupervisor, fn ->
+  risky_operation()
+end)
+```
+
+### Agent (estado simples)
+```elixir
+{:ok, pid} = Agent.start_link(fn -> [] end, name: :my_agent)
+
+Agent.update(:my_agent, fn list -> [new_item | list] end)
+Agent.get(:my_agent, & &1)
+Agent.get_and_update(:my_agent, fn list -> {list, []} end)
+Agent.stop(:my_agent)
+```
+
+---
+
+## 6. Testes com ExUnit
+
+### Estrutura básica
+```elixir
+defmodule MyApp.UserTest do
+  use ExUnit.Case, async: true  # async: true para paralelismo
+
+  # Configuração por describe
+  setup do
+    user = %MyApp.User{id: 1, name: "Alice", email: "alice@test.com"}
+    {:ok, user: user}  # contexto disponível nos testes
+  end
+
+  describe "new/3" do
+    test "cria usuário com valores padrão", %{user: user} do
+      assert user.name == "Alice"
+      assert user.active == true
+    end
+
+    test "email deve conter @" do
+      assert_raise ArgumentError, fn ->
+        MyApp.User.new(1, "Bob", "invalid-email")
+      end
+    end
+  end
+
+  describe "activate/1" do
+    test "retorna usuário ativo" do
+      user = %MyApp.User{active: false}
+      result = MyApp.User.activate(user)
+      assert result.active == true
+    end
+  end
+end
+```
+
+### Assertions
+```elixir
+# Básicas
+assert expression                         # verifica se é truthy
+refute expression                         # verifica se é falsy
+assert value == expected
+assert value === expected                 # strict (tipo e valor)
+
+# Comparações
+assert length(list) == 3
+assert map_size(map) > 0
+
+# Exceções
+assert_raise RuntimeError, fn -> raise "oops" end
+assert_raise ArgumentError, ~r/invalid/, fn -> bad_call() end
+
+# Mensagens recebidas (processos)
+assert_receive {:ok, _value}, 1000        # timeout em ms
+refute_receive {:error, _}
+
+# Float
+assert_in_delta 3.14, :math.pi(), 0.01
+
+# Pattern matching em assert
+assert {:ok, %{id: id}} = create_user()  # bind e verifica estrutura
+
+# Catch para fluxo de throw
+assert catch_throw(fn -> throw(:value) end) == :value
+assert catch_exit(fn -> exit(:reason) end) == :reason
+assert catch_error(fn -> raise "boom" end)
+```
+
+### Tags e filtros
+```elixir
+# Tags em módulo inteiro
+@moduletag :integration
+
+# Tag em teste individual
+@tag :slow
+@tag timeout: 10_000
+@tag :skip
+test "teste que pula" do ... end
+
+# Rodar com filtros
+# mix test --only integration
+# mix test --exclude slow
+# mix test --include slow
+```
+
+### Setup e Callbacks
+```elixir
+defmodule MyApp.DbTest do
+  use ExUnit.Case
+
+  setup_all do
+    # Executa uma vez para todos os testes do módulo
+    {:ok, db} = MyApp.DB.start_link()
+    on_exit(fn -> MyApp.DB.stop(db) end)
+    {:ok, db: db}
+  end
+
+  setup %{db: db} do
+    # Executa antes de cada teste
+    MyApp.DB.truncate(db)
+    :ok
+  end
+end
+```
+
+### ExUnit.Case doctests
+```elixir
+defmodule MyApp.Math do
+  @doc """
+  Soma dois números.
+
+      iex> MyApp.Math.add(1, 2)
+      3
+
+      iex> MyApp.Math.add(0, 0)
+      0
+  """
+  def add(a, b), do: a + b
+end
+
+defmodule MyApp.MathTest do
+  use ExUnit.Case
+  doctest MyApp.Math  # executa os exemplos do @doc como testes
+end
+```
+
+---
+
+## 7. Logger
+
+### Configuração (config/config.exs)
+```elixir
+import Config
+
+config :logger, level: :debug   # :debug | :info | :warning | :error
+
+config :logger, :default_formatter,
+  format: "[$l] $message\n",
+  metadata: [:request_id, :user_id]
+
+# Desabilitar logger em testes
+config :logger, level: :warning
+
+# Por módulo específico
+config :logger, MyApp.NoisyModule, level: :warning
+```
+
+### Uso nos módulos
+```elixir
+defmodule MyApp.Service do
+  require Logger
+
+  def process(data) do
+    Logger.debug("Processando: #{inspect(data)}")
+    Logger.info("Iniciando processamento")
+
+    case do_work(data) do
+      {:ok, result} ->
+        Logger.info("Sucesso", result_size: byte_size(result))
+        {:ok, result}
+
+      {:error, reason} ->
+        Logger.warning("Falhou: #{inspect(reason)}")
+        {:error, reason}
+    end
+  rescue
+    e ->
+      Logger.error("Exceção: #{Exception.message(e)}", error: e)
+      reraise e, __STACKTRACE__
+  end
+end
+```
+
+### Níveis de log (ordem de severidade)
+```
+:debug      # desenvolvimento, diagnóstico
+:info       # eventos normais
+:notice     # eventos significativos, normais
+:warning    # algo inesperado, mas tolerável
+:error      # erros que precisam atenção
+:critical   # falhas críticas
+:alert      # ação imediata necessária
+:emergency  # sistema inoperante
+```
+
+### Metadata
+```elixir
+# Global (todos os logs do processo)
+Logger.metadata(request_id: "abc123", user_id: 42)
+
+# Por chamada específica
+Logger.info("Compra realizada", order_id: order.id, amount: order.total)
+
+# Resetar metadata
+Logger.metadata([])
+```
+
+---
+
+## 8. EEx (Embedded Elixir / Templates)
+
+### Tags EEx
+```
+<% código %>          executa código (sem output)
+<%= expressão %>      executa e imprime resultado
+<%% ... %%>           escapa, não executa (retorna literal)
+<%!-- comentário --%> comentário (ignorado)
+```
+
+### APIs de uso
+```elixir
+# 1. Avaliação direta (mais lento, bom para templates dinâmicos)
+EEx.eval_string("Olá, <%= name %>!", name: "Alice")
+#=> "Olá, Alice!"
+
+EEx.eval_file("templates/email.html.eex", assigns)
+
+# 2. Compilar como função (mais rápido, preferido)
+defmodule MyApp.Templates do
+  require EEx
+
+  EEx.function_from_string(:def, :render_greeting, "Olá, <%= name %>!", [:name])
+  EEx.function_from_file(:def, :render_email, "priv/templates/email.html.eex", [:assigns])
+end
+
+# Uso:
+MyApp.Templates.render_greeting("Bob")  #=> "Olá, Bob!"
+```
+
+### Template com assigns (@var)
+```elixir
+# Usando SmartEngine (padrão): @var acessa assigns
+template = """
+<html>
+  <body>
+    <h1><%= @title %></h1>
+    <%= for item <- @items do %>
+      <li><%= item %></li>
+    <% end %>
+  </body>
+</html>
+"""
+
+EEx.eval_string(template, assigns: [title: "Lista", items: ["a", "b", "c"]])
+```
+
+### Compilar para análise (AST)
+```elixir
+# Para integração avançada ou engine customizada
+ast = EEx.compile_string("<%= 1 + 1 %>")
+{result, _} = Code.eval_quoted(ast)
+```
+
+---
+
+## 9. IEx (Shell Interativo)
+
+### Comandos essenciais
+```elixir
+h Module              # documentação do módulo
+h Module.function/arity  # doc de função específica
+i value               # informações sobre um valor
+t Module.type         # tipos do módulo
+
+# Exemplos
+h String
+h String.split/2
+h Enum
+i "hello"
+i [1,2,3]
+t GenServer.on_start
+```
+
+### Helpers e inspeção
+```elixir
+IO.inspect(value)                           # imprime com metadados
+IO.inspect(value, label: "meu valor")       # com label
+IO.inspect(value, limit: :infinity)         # sem truncamento
+IO.inspect(value, pretty: true)             # formatado
+IO.inspect(value, structs: false)           # mostra como map
+
+# Dentro de pipeline (não altera o fluxo)
+[1,2,3]
+|> IO.inspect(label: "antes")
+|> Enum.map(&(&1 * 2))
+|> IO.inspect(label: "depois")
+```
+
+### Sessão IEx
+```bash
+iex                  # shell simples
+iex -S mix           # com projeto Mix carregado
+iex -S mix phx.server  # com servidor Phoenix
+iex --name alice@localhost  # nomeado (cluster)
+```
+
+```elixir
+# Dentro do IEx:
+recompile()           # recompila o projeto sem reiniciar
+r ModuleName          # recarrega módulo específico
+c "path/to/file.ex"  # compila e carrega arquivo
+ls                    # lista diretório
+cd "path"             # muda diretório
+pwd                   # diretório atual
+
+# Recuperar valor de expressões anteriores
+v(1)                  # valor da 1ª expressão
+v(-1)                 # valor da última expressão
+```
+
+### IEx.pry – debugging
+```elixir
+defmodule MyApp.Debug do
+  def problematic_function(x) do
+    require IEx
+    IEx.pry()  # para execução aqui (apenas em iex -S mix)
+    x * 2
+  end
+end
+```
+
+### IEx.configure
+```elixir
+# ~/.iex.exs (configuração pessoal)
+IEx.configure(
+  colors: [enabled: true],
+  inspect: [limit: 50, pretty: true],
+  history_size: 100
+)
+
+import_if_available(Ecto.Query)
+alias MyApp.{User, Order, Repo}
+```
+
+---
+
+## 10. Padrões e Boas Práticas
+
+### Convenções de nomenclatura
+```elixir
+# Módulos: PascalCase
+defmodule MyApp.UserService do
+
+# Funções e variáveis: snake_case
+def create_user(attrs) do
+
+# Funções que retornam bool: terminam em ?
+def valid?(changeset)
+def empty?(list)
+
+# Funções que levantam exceção: terminam em !
+def fetch!(key)   # levanta se não encontrar
+def save!(data)   # levanta se falhar
+
+# Funções "bang" vs "safe"
+File.read("file.txt")   #=> {:ok, content} | {:error, reason}
+File.read!("file.txt")  #=> content | levanta RuntimeError
+
+# Constantes de módulo
+@max_retries 3
+@default_timeout 5_000
+@behaviour MyApp.Behaviour
+```
+
+### Estrutura de retorno consistente
+```elixir
+# Sempre retornar {:ok, value} ou {:error, reason}
+def find_user(id) do
+  case Repo.get(User, id) do
+    nil  -> {:error, :not_found}
+    user -> {:ok, user}
+  end
+end
+
+# Encadeamento com with
+def process_order(user_id, params) do
+  with {:ok, user}   <- find_user(user_id),
+       {:ok, order}  <- create_order(user, params),
+       {:ok, _email} <- send_confirmation(order) do
+    {:ok, order}
+  end
+end
+```
+
+### @spec – tipagem
+```elixir
+@spec add(integer(), integer()) :: integer()
+def add(a, b), do: a + b
+
+@spec find_user(pos_integer()) :: {:ok, User.t()} | {:error, :not_found}
+def find_user(id), do: ...
+
+@spec process([map()], keyword()) :: {:ok, list()} | {:error, String.t()}
+def process(items, opts \\ []), do: ...
+
+# Tipos compostos comuns
+@type id :: pos_integer()
+@type result(t) :: {:ok, t} | {:error, String.t()}
+@type option(t) :: t | nil
+```
+
+### Macros e metaprogramação
+```elixir
+defmodule MyApp.DSL do
+  defmacro route(method, path, do: block) do
+    quote do
+      def unquote(:"handle_#{method}")(unquote(path)) do
+        unquote(block)
+      end
+    end
+  end
+end
+
+# use (injeta comportamento)
+defmodule MyApp.Base do
+  defmacro __using__(opts) do
+    quote do
+      import MyApp.Base
+      @behaviour MyApp.Behaviour
+      Module.register_attribute(__MODULE__, :routes, accumulate: true)
+    end
+  end
+end
+```
+
+### Behaviours (interfaces)
+```elixir
+defmodule MyApp.Notifier do
+  @callback send_notification(user :: map(), message :: String.t()) ::
+              {:ok, reference()} | {:error, String.t()}
+
+  @callback supported_channels() :: [atom()]
+
+  @optional_callbacks supported_channels: 0
+end
+
+defmodule MyApp.EmailNotifier do
+  @behaviour MyApp.Notifier
+
+  @impl true
+  def send_notification(user, message) do
+    # implementação
+    {:ok, make_ref()}
+  end
+
+  @impl true
+  def supported_channels, do: [:email, :html]
+end
+```
+
+---
+
+## 11. Configuração e Releases
+
+### Config dinâmica em runtime
+```elixir
+# config/runtime.exs (preferido para produção)
+import Config
+
+config :my_app, MyApp.Repo,
+  url: System.fetch_env!("DATABASE_URL"),
+  pool_size: String.to_integer(System.get_env("POOL_SIZE", "10"))
+
+config :my_app, secret_key_base: System.fetch_env!("SECRET_KEY_BASE")
+```
+
+### Application env
+```elixir
+# Ler configuração em runtime
+Application.get_env(:my_app, :timeout, 5000)
+Application.fetch_env!(:my_app, :api_key)
+
+# Bom para defaults em módulos
+defmodule MyApp.Client do
+  @default_timeout Application.compile_env(:my_app, [:client, :timeout], 5000)
+
+  def call(url) do
+    timeout = Application.get_env(:my_app, [:client, :timeout], @default_timeout)
+    # ...
+  end
+end
+```
+
+---
+
+## 12. Erros Comuns e Soluções
+
+| Erro | Causa | Solução |
+|------|-------|---------|
+| `FunctionClauseError` | Nenhuma cláusula matchou | Adicionar cláusula fallback ou verificar tipos de entrada |
+| `MatchError` | Pattern match falhou com `=` | Usar `case` ou verificar o valor antes |
+| `UndefinedFunctionError` | Função não existe ou não foi importada | Verificar `alias`, `import` e `use` |
+| `KeyError` | Acesso a chave inexistente em map com `.` | Usar `Map.get/3` com default |
+| `ArgumentError` | Argumento inválido para função | Verificar typo, adicionar `when` guards |
+| `CaseClauseError` | Nenhuma cláusula do `case` matchou | Adicionar cláusula `_ ->` |
+| `WithClauseError` | `with` sem cláusula `else` para o padrão | Adicionar `else` clause |
+| `CompileError` | Erro em tempo de compilação | Verificar sintaxe, módulos circulares |
+| `Dialyxir warning` | Typespec inconsistente | Corrigir `@spec` |
+
+---
+
+## 13. Referências Rápidas
+
+### Links oficiais (v1.19.5)
+- Kernel: https://hexdocs.pm/elixir/1.19.5/Kernel.html
+- EEx: https://hexdocs.pm/eex/1.19.5/EEx.html
+- ExUnit: https://hexdocs.pm/ex_unit/1.19.5/ExUnit.html
+- IEx: https://hexdocs.pm/iex/1.19.5/IEx.html
+- Logger: https://hexdocs.pm/logger/1.19.5/Logger.html
+- Mix: https://hexdocs.pm/mix/1.19.5/Mix.html
+- Guia: https://hexdocs.pm/elixir/introduction.html
+
+### Módulos stdlib mais usados
+```
+Kernel       - primitivas, guards, operadores
+String       - manipulação de strings UTF-8
+Integer      - operações com inteiros
+Float        - operações com floats
+Atom         - operações com atoms
+List         - listas encadeadas
+Map          - mapas chave-valor
+Keyword      - keyword lists
+Tuple        - tuplas
+Enum         - coleções (eager)
+Stream       - coleções (lazy)
+IO           - entrada e saída
+File         - sistema de arquivos
+Path         - caminhos de arquivo
+System       - informações do sistema
+Process      - processos Elixir
+Agent        - estado simples
+GenServer    - cliente-servidor genérico
+Supervisor   - árvore de supervisão
+Task         - computação assíncrona
+Registry     - registro chave-processo
+Application  - gerenciamento de aplicações
+Config       - configuração
+Regex        - expressões regulares
+DateTime     - data e hora com timezone
+Date         - apenas data
+Time         - apenas hora
+URI          - manipulação de URIs
+Jason / Poison - JSON (libs externas)
+```

--- a/docs/skills/FLOW.md
+++ b/docs/skills/FLOW.md
@@ -1,0 +1,869 @@
+# Flow - Skill Completa para Desenvolvedores Elixir
+
+Guia prático e completo para usar a biblioteca Flow em projetos Elixir.
+
+## O que e Flow?
+
+Flow permite expressar computacoes paralelas sobre colecoes em Elixir, similar ao `Enum` e `Stream`, mas executando operacoes em paralelo usando processos `GenStage`. E ideal para processamento de grandes volumes de dados (bounded ou unbounded).
+
+> **Regra de ouro**: Flow mostra melhorias reais com colecoes grandes. Por padrao trabalha em batches de 500 itens.
+
+---
+
+## 1. Instalacao
+
+```elixir
+# mix.exs
+def deps do
+  [{:flow, "~> 1.0"}]
+end
+```
+
+```bash
+mix deps.get
+```
+
+---
+
+## 2. Conceitos Fundamentais
+
+### Enum vs Stream vs Flow
+
+```elixir
+# Enum: carrega TUDO em memoria, sequencial
+File.stream!("grande.txt")
+|> Enum.flat_map(&String.split(&1, " "))
+|> Enum.reduce(%{}, fn word, acc -> Map.update(acc, word, 1, &(&1 + 1)) end)
+
+# Stream: lazy, sequencial, um item por vez
+File.stream!("grande.txt")
+|> Stream.flat_map(&String.split(&1, " "))
+|> Enum.reduce(%{}, fn word, acc -> Map.update(acc, word, 1, &(&1 + 1)) end)
+
+# Flow: lazy, PARALELO, em batches
+File.stream!("grande.txt")
+|> Flow.from_enumerable()
+|> Flow.flat_map(&String.split(&1, " "))
+|> Flow.partition()
+|> Flow.reduce(fn -> %{} end, fn word, acc ->
+  Map.update(acc, word, 1, &(&1 + 1))
+end)
+|> Enum.to_list()
+```
+
+### O Pipeline de Execucao
+
+```
+[Producers]           # fonte de dados
+     |
+[Mapper Stages]       # map, filter, flat_map (paralelo, stateless)
+     |
+[PartitionDispatcher] # roteia dados por hash
+     |
+[Reducer Stages]      # reduce, group_by (paralelo por particao, stateful)
+     |
+[Consumer/Output]     # Enum.to_list, start_link, etc.
+```
+
+### As 3 Fases de um Stage
+
+1. **Mapping/Filtering** - `map/2`, `filter/2`, `flat_map/2`, `reject/2`
+2. **Reducing** - `reduce/3`, `group_by/3`, `emit_and_reduce/3`
+3. **Emitting** - `emit/2`, `on_trigger/2`
+
+> **Regra**: mappers NAO podem vir depois de reducers na mesma particao. Reducers so podem aparecer UMA vez por particao.
+
+---
+
+## 3. Criando Flows - Fontes de Dados
+
+### A partir de Enumerables
+
+```elixir
+# Uma fonte
+[1, 2, 3, 4, 5]
+|> Flow.from_enumerable()
+|> Flow.map(&(&1 * 2))
+|> Enum.to_list()
+
+# Multiplas fontes (RECOMENDADO para evitar gargalos)
+streams = for file <- File.ls!("data/") do
+  File.stream!(Path.join("data", file), read_ahead: 100_000)
+end
+
+streams
+|> Flow.from_enumerables()
+|> Flow.flat_map(&String.split(&1, " "))
+|> Flow.partition()
+|> Flow.reduce(fn -> %{} end, fn word, acc ->
+  Map.update(acc, word, 1, &(&1 + 1))
+end)
+|> Enum.to_list()
+```
+
+### A partir de GenStage producers
+
+```elixir
+# Producers ja rodando
+Flow.from_stages([pid1, pid2, pid3])
+|> Flow.map(&process/1)
+|> Enum.to_list()
+
+# Child specs (producers iniciados junto com o flow)
+specs = [{MyProducer, arg1}, {MyProducer, arg2}]
+Flow.from_specs(specs)
+|> Flow.map(&process/1)
+|> Flow.start_link()
+```
+
+---
+
+## 4. Operacoes de Mapeamento (Stateless, Paralelas)
+
+```elixir
+flow = Flow.from_enumerable(1..1000)
+
+# map - transforma cada elemento
+flow |> Flow.map(&(&1 * 2))
+
+# flat_map - transforma e achata
+flow |> Flow.flat_map(fn x -> [x, x * 2] end)
+
+# filter - filtra elementos
+flow |> Flow.filter(&(rem(&1, 2) == 0))
+
+# reject - rejeita elementos (inverso do filter)
+flow |> Flow.reject(&(rem(&1, 2) == 0))
+
+# map_values - mapeia valores de tuplas {key, value}
+Flow.from_enumerable([a: 1, b: 2])
+|> Flow.map_values(&(&1 * 2))
+# => [a: 2, b: 4]
+
+# map_batch - processa o batch inteiro ANTES de map/reduce
+# Util para preload de dados
+Flow.from_enumerable(user_ids)
+|> Flow.map_batch(fn ids ->
+  users = Repo.all(from u in User, where: u.id in ^ids)
+  users_map = Map.new(users, &{&1.id, &1})
+  Enum.map(ids, &Map.fetch!(users_map, &1))
+end)
+|> Flow.map(&process_user/1)
+```
+
+---
+
+## 5. Particionamento - O Coracao do Flow
+
+Particionamento garante que dados relacionados vao para o mesmo stage.
+
+```elixir
+# Particionamento padrao (hash do elemento inteiro)
+flow |> Flow.partition()
+
+# Por campo de tupla
+flow |> Flow.partition(key: {:elem, 0})   # primeiro elem da tupla
+
+# Por chave de mapa
+flow |> Flow.partition(key: {:key, :user_id})
+
+# Por funcao customizada
+flow |> Flow.partition(key: fn event -> event.category end)
+
+# Hash customizado (controle total do roteamento)
+flow |> Flow.partition(hash: fn event ->
+  {event, :erlang.phash2(event.user_id, _num_partitions = 4)}
+end)
+
+# Numero de stages (padrao: System.schedulers_online())
+flow |> Flow.partition(stages: 8)
+```
+
+### Quando usar partition?
+
+- **USE** quando precisa agrupar dados (contagem de palavras, aggregacoes por chave)
+- **NAO USE** para problemas "embarrassingly parallel" (cada item e independente)
+- Particionamento desnecessario aumenta uso de memoria e reduz throughput
+
+### Shuffle vs Partition
+
+```elixir
+# shuffle - redistribui sem garantia de agrupamento (DemandDispatcher)
+flow |> Flow.shuffle(stages: 4)
+
+# partition - agrupa por hash (PartitionDispatcher)
+flow |> Flow.partition(stages: 4)
+```
+
+---
+
+## 6. Operacoes de Reducao (Stateful, por Particao)
+
+### reduce
+
+```elixir
+# Acumulador e funcao redutora
+Flow.from_enumerable(words)
+|> Flow.partition()
+|> Flow.reduce(fn -> %{} end, fn word, acc ->
+  Map.update(acc, word, 1, &(&1 + 1))
+end)
+|> Enum.to_list()
+# => [{"hello", 3}, {"world", 2}, ...]
+```
+
+### group_by
+
+```elixir
+# Agrupa por chave
+Flow.from_enumerable(~w[the quick brown fox], stages: 1)
+|> Flow.group_by(&String.length/1)
+|> Enum.to_list()
+# => [{3, ["fox", "the"]}, {5, ["brown", "quick"]}]
+
+# group_by_key para tuplas {key, value}
+Flow.from_enumerable([foo: 1, foo: 2, bar: 3])
+|> Flow.group_by_key()
+|> Flow.emit(:state)
+|> Enum.to_list()
+# => [%{foo: [2, 1], bar: [3]}]
+```
+
+### emit_and_reduce (emite E reduz ao mesmo tempo)
+
+```elixir
+# Sliding window de 3 elementos
+Flow.from_enumerable(1..5, stages: 1)
+|> Flow.emit_and_reduce(fn -> [] end, fn event, acc ->
+  acc = [event | acc] |> Enum.take(3)
+  {[Enum.reverse(acc)], acc}
+end)
+|> Enum.filter(&is_list/1)
+# => [[1], [1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5]]
+```
+
+### uniq / uniq_by
+
+```elixir
+# Elementos unicos (por particao!)
+Flow.from_enumerable(1..100)
+|> Flow.partition(stages: 1)
+|> Flow.uniq_by(&rem(&1, 2))
+|> Enum.sort()
+# => [1, 2]
+```
+
+> **Atencao**: `uniq_by` funciona POR PARTICAO. Para unicidade global, particione pela mesma chave usada no uniq_by.
+
+---
+
+## 7. Controlando a Emissao de Resultados
+
+### emit/2
+
+```elixir
+# :events - emite os eventos processados (padrao)
+flow |> Flow.reduce(...) |> Flow.emit(:events)
+
+# :state - emite o estado acumulado como um unico evento
+flow |> Flow.reduce(...) |> Flow.emit(:state)
+
+# :nothing - nao emite nada (side-effects only)
+flow |> Flow.reduce(...) |> Flow.emit(:nothing)
+```
+
+### on_trigger/2 (controle total)
+
+```elixir
+# Aridade 1: so recebe o estado
+flow
+|> Flow.reduce(fn -> %{} end, &Map.put(&2, &1, true))
+|> Flow.on_trigger(fn map ->
+  {[map_size(map)], map}  # {eventos_emitidos, novo_acumulador}
+end)
+
+# Aridade 2: recebe estado + info da particao
+flow
+|> Flow.reduce(fn -> %{} end, reducer_fn)
+|> Flow.on_trigger(fn state, {partition_index, total_partitions} ->
+  {[state], state}
+end)
+
+# Aridade 3: recebe estado + particao + info da window/trigger
+flow
+|> Flow.reduce(fn -> %{} end, reducer_fn)
+|> Flow.on_trigger(fn state, _partition, {window_type, window_id, trigger_name} ->
+  IO.puts("Window #{window_type}/#{window_id} triggered by #{inspect(trigger_name)}")
+  {[state], %{}}  # emite estado e reseta acumulador
+end)
+```
+
+---
+
+## 8. Windows - Dividindo Dados no Tempo
+
+### Global Window (padrao)
+
+```elixir
+# Todos os eventos em uma unica janela
+window = Flow.Window.global()
+
+# Com trigger a cada 10 eventos
+window = Flow.Window.global() |> Flow.Window.trigger_every(10)
+
+Flow.from_enumerable(1..100)
+|> Flow.partition(window: window, stages: 1)
+|> Flow.reduce(fn -> 0 end, &(&1 + &2))
+|> Flow.emit(:state)
+|> Enum.to_list()
+# => [55, 210, 465, 820, 1275, 1830, 2485, 3240, 4095, 5050, 5050]
+#     ^cada trigger emite soma parcial          ^ultimo e o :done
+```
+
+### Fixed Window (event time)
+
+```elixir
+# Janelas de 1 hora baseadas no timestamp do evento
+window = Flow.Window.fixed(1, :hour, fn {_word, timestamp} -> timestamp end)
+
+data = [
+  {"elixir", 0}, {"elixir", 1_000}, {"erlang", 60_000},
+  {"concurrency", 3_200_000}, {"elixir", 4_000_000},
+  {"erlang", 5_000_000}, {"erlang", 6_000_000}
+]
+
+Flow.from_enumerable(data, max_demand: 5, stages: 1)
+|> Flow.partition(window: window, stages: 1)
+|> Flow.reduce(fn -> %{} end, fn {word, _}, acc ->
+  Map.update(acc, word, 1, &(&1 + 1))
+end)
+|> Flow.emit(:state)
+|> Enum.to_list()
+# => [%{"elixir" => 2, "erlang" => 1, "concurrency" => 1},
+#     %{"elixir" => 1, "erlang" => 2}]
+```
+
+### Fixed Window com Lateness (dados atrasados)
+
+```elixir
+window =
+  Flow.Window.fixed(1, :hour, fn {_word, timestamp} -> timestamp end)
+  |> Flow.Window.allowed_lateness(5, :minute)
+
+# Agora a window emite :watermark quando termina,
+# e :done so apos o periodo de latencia
+```
+
+### Count Window
+
+```elixir
+# Nova janela a cada 10 eventos
+window = Flow.Window.count(10)
+
+Flow.from_enumerable(1..100)
+|> Flow.partition(window: window, stages: 1)
+|> Flow.reduce(fn -> 0 end, &(&1 + &2))
+|> Flow.emit(:state)
+|> Enum.to_list()
+# => [55, 155, 255, 355, 455, 555, 655, 755, 855, 955, 0]
+```
+
+### Periodic Window (processing time)
+
+```elixir
+# Nova janela a cada 5 segundos
+window = Flow.Window.periodic(5, :second)
+```
+
+### Triggers
+
+```elixir
+# Trigger a cada N elementos
+window = Flow.Window.global() |> Flow.Window.trigger_every(100)
+
+# Trigger periodico (processing time, impreciso por natureza)
+window = Flow.Window.global() |> Flow.Window.trigger_periodically(1, :second)
+
+# Trigger customizado (punctuation)
+window = Flow.Window.global()
+|> Flow.Window.trigger(
+  fn -> 0 end,  # acumulador inicial do trigger
+  fn events, count ->
+    length = length(events)
+    if count + length >= 1000 do
+      {pre, pos} = Enum.split(events, 1000 - count)
+      {:trigger, :my_checkpoint, pre, pos, 0}
+    else
+      {:cont, count + length}
+    end
+  end
+)
+
+# Trigger por mensagem (timers customizados)
+# Envie {:trigger, name} para self() dentro do accumulator
+flow
+|> Flow.reduce(fn ->
+  Process.send_after(self(), {:trigger, :my_timer}, 5_000)
+  %{}
+end, reducer_fn)
+```
+
+### Info do Trigger no on_trigger/2
+
+```elixir
+# O terceiro argumento do on_trigger revela o que causou o trigger:
+# {:global, :global, :done}                    - global window finalizada
+# {:global, :global, {:every, 20}}             - trigger_every
+# {:global, :global, {:periodically, 1, :second}} - trigger_periodically
+# {:fixed, window_timestamp, :done}            - fixed window finalizada
+# {:fixed, window_timestamp, :watermark}       - watermark (antes do lateness)
+# {:count, window_index, :done}                - count window finalizada
+```
+
+---
+
+## 9. Joins - Combinando Dois Flows
+
+### bounded_join (dados finitos)
+
+```elixir
+posts = [%{id: 1, title: "hello"}, %{id: 2, title: "world"}]
+comments = [{1, "excellent"}, {1, "outstanding"}, {2, "great"}, {3, "unknown"}]
+
+flow = Flow.bounded_join(
+  :inner,                                    # :inner | :left_outer | :right_outer | :full_outer
+  Flow.from_enumerable(posts),               # flow esquerdo
+  Flow.from_enumerable(comments),            # flow direito
+  & &1.id,                                   # chave esquerda
+  & elem(&1, 0),                             # chave direita
+  fn post, {_id, comment} ->                 # funcao de join
+    Map.put(post, :comment, comment)
+  end
+)
+
+Enum.sort(flow)
+# => [%{id: 1, title: "hello", comment: "excellent"},
+#     %{id: 1, title: "hello", comment: "outstanding"},
+#     %{id: 2, title: "world", comment: "great"}]
+```
+
+### window_join (com janelas)
+
+```elixir
+window = Flow.Window.fixed(1, :hour, fn
+  {_, _, timestamp} -> timestamp
+  %{timestamp: timestamp} -> timestamp
+end)
+
+Flow.window_join(:inner, left_flow, right_flow, window,
+  &left_key/1, &right_key/1, &join_fn/2, stages: 4)
+```
+
+---
+
+## 10. Departition - Mergindo Resultados de Particoes
+
+```elixir
+# Conta palavras e merge todos os resultados em um unico mapa
+File.stream!("arquivo.txt")
+|> Flow.from_enumerable()
+|> Flow.flat_map(&String.split/1)
+|> Flow.partition()
+|> Flow.reduce(fn -> %{} end, fn word, acc ->
+  Map.update(acc, word, 1, &(&1 + 1))
+end)
+|> Flow.departition(
+  fn -> Map.new() end,                                    # acumulador inicial
+  fn partition_state, acc -> Map.merge(partition_state, acc) end,  # merge
+  fn acc -> acc end                                        # finalizacao
+)
+|> Enum.to_list()
+# => [%{"hello" => 5, "world" => 3, ...}]  # um unico mapa consolidado
+```
+
+### take_sort (top N)
+
+```elixir
+urls = ~w(www.foo.com www.bar.com www.foo.com www.foo.com www.baz.com)
+
+urls
+|> Flow.from_enumerable()
+|> Flow.partition()
+|> Flow.reduce(fn -> %{} end, fn url, map ->
+  Map.update(map, url, 1, &(&1 + 1))
+end)
+|> Flow.take_sort(3, fn {_url_a, count_a}, {_url_b, count_b} ->
+  count_b <= count_a
+end)
+|> Enum.to_list()
+# => [[{"www.foo.com", 3}, {"www.bar.com", 1}, {"www.baz.com", 1}]]
+```
+
+---
+
+## 11. Flows Supervisionados (Producao)
+
+### Inline na supervision tree
+
+```elixir
+children = [
+  {Flow,
+   Flow.from_specs([{MyProducer, []}])
+   |> Flow.map(&process/1)
+   |> Flow.partition()
+   |> Flow.reduce(fn -> %{} end, &aggregate/2)}
+]
+
+Supervisor.start_link(children, strategy: :one_for_one)
+```
+
+### Modulo dedicado
+
+```elixir
+defmodule MyApp.WordCounter do
+  use Flow
+
+  def start_link(_opts) do
+    Flow.from_specs([{MyApp.EventProducer, []}])
+    |> Flow.flat_map(&String.split(&1, " "))
+    |> Flow.partition()
+    |> Flow.reduce(fn -> %{} end, fn word, acc ->
+      Map.update(acc, word, 1, &(&1 + 1))
+    end)
+    |> Flow.start_link()
+  end
+end
+
+# Na supervision tree:
+children = [MyApp.WordCounter]
+```
+
+### Com consumers externos (into_stages / into_specs)
+
+```elixir
+# Consumers ja rodando
+{:ok, pid} = Flow.into_stages(flow, [consumer_pid1, consumer_pid2])
+
+# Consumer specs iniciados junto
+consumer_specs = [{MyConsumer, arg, []}]
+{:ok, pid} = Flow.into_specs(flow, [{MyConsumer, []}])
+```
+
+### Com producer_consumers intermediarios (through_stages / through_specs)
+
+```elixir
+# Passar por producer_consumers existentes
+flow
+|> Flow.through_stages([rate_limiter_pid])
+|> Flow.partition()
+|> Flow.reduce(...)
+|> Flow.start_link()
+
+# Ou com specs
+flow
+|> Flow.through_specs([{RateLimiter, [], []}])
+|> Flow.partition()
+|> Flow.reduce(...)
+|> Flow.start_link()
+```
+
+---
+
+## 12. Patterns e Receitas Praticas
+
+### Contagem de Palavras (completo e otimizado)
+
+```elixir
+empty_space = :binary.compile_pattern(" ")
+parent = self()
+
+File.stream!("big_file.txt", read_ahead: 100_000)
+|> Flow.from_enumerable()
+|> Flow.flat_map(&String.split(&1, empty_space))
+|> Flow.partition()
+|> Flow.reduce(fn -> :ets.new(:words, []) end, fn word, ets ->
+  :ets.update_counter(ets, word, {2, 1}, {word, 0})
+  ets
+end)
+|> Flow.on_trigger(fn ets ->
+  :ets.give_away(ets, parent, [])
+  {[ets], :unused}
+end)
+|> Enum.to_list()
+```
+
+### Processamento de Multiplos Arquivos
+
+```elixir
+streams = for file <- File.ls!("data/") do
+  File.stream!(Path.join("data", file), read_ahead: 100_000)
+end
+
+streams
+|> Flow.from_enumerables()
+|> Flow.flat_map(&parse_line/1)
+|> Flow.partition(key: {:key, :category})
+|> Flow.reduce(fn -> %{} end, &aggregate/2)
+|> Enum.to_list()
+```
+
+### Pipeline ETL
+
+```elixir
+Flow.from_enumerable(source_stream)
+|> Flow.map(&extract/1)               # Extract
+|> Flow.filter(&valid?/1)
+|> Flow.partition(key: {:key, :id})
+|> Flow.map(&transform/1)             # Transform
+|> Flow.reduce(fn -> [] end, fn record, acc ->
+  [record | acc]                       # Batch
+end)
+|> Flow.on_trigger(fn batch ->
+  load(batch)                          # Load
+  {[], []}                             # Reset batch
+end)
+|> Flow.run()
+```
+
+### Session Windows (gap entre eventos)
+
+```elixir
+max_gap = 1_000_000  # 1 segundo em microsegundos
+
+Flow.from_enumerable(events)
+|> Flow.partition(key: fn {k, _} -> k end, stages: 1)
+|> Flow.emit_and_reduce(fn -> %{} end, fn {word, time}, acc ->
+  {count, previous_time} = Map.get(acc, word, {1, time})
+
+  if time - previous_time > max_gap do
+    {[{word, {count, previous_time}}], Map.put(acc, word, {1, time})}
+  else
+    {[], Map.update(acc, word, {1, time}, fn {count, _} -> {count + 1, time} end)}
+  end
+end)
+|> Flow.on_trigger(fn acc -> {Enum.to_list(acc), :unused} end)
+|> Enum.to_list()
+```
+
+### Streaming com Checkpoints
+
+```elixir
+window =
+  Flow.Window.global()
+  |> Flow.Window.trigger_every(1000)
+  |> Flow.Window.trigger_periodically(30, :second)
+
+Flow.from_specs([{EventSource, []}])
+|> Flow.partition(window: window)
+|> Flow.reduce(fn -> %{} end, &process_event/2)
+|> Flow.on_trigger(fn state, _partition, {_, _, trigger} ->
+  case trigger do
+    {:every, _} -> save_checkpoint(state)
+    {:periodically, _, _} -> log_progress(state)
+    :done -> save_final(state)
+  end
+  {[], state}
+end)
+|> Flow.start_link()
+```
+
+---
+
+## 13. Uso em Livebook
+
+```elixir
+# Opcao 1: stream nao-linkado (RECOMENDADO)
+Flow.from_enumerable([1, 2, 3])
+|> Flow.map(&(&1 * 2))
+|> Flow.stream(link: false)
+|> Enum.to_list()
+
+# Opcao 2: trap exits antes do flow
+Process.flag(:trap_exit, true)
+```
+
+---
+
+## 14. Performance e Tuning
+
+### Demand (controle de batch)
+
+```elixir
+# max_demand: tamanho maximo do batch (padrao: 500)
+# min_demand: quando pedir mais dados (padrao: max_demand / 2)
+# O batch efetivo e max_demand - min_demand
+
+# Para IO-bound: batches menores
+Flow.from_enumerable(stream, max_demand: 20, min_demand: 5)
+
+# Para CPU-bound com dados grandes: batches maiores (padrao ja e bom)
+Flow.from_enumerable(stream, max_demand: 1000)
+
+# Para testes/debug: force 1 por vez
+Flow.from_enumerable(stream, max_demand: 1)
+```
+
+### Numero de Stages
+
+```elixir
+# Padrao: System.schedulers_online() (numero de cores)
+# CPU-bound: mantenha o padrao
+flow |> Flow.partition(stages: System.schedulers_online())
+
+# IO-bound: aumente
+flow |> Flow.partition(stages: System.schedulers_online() * 2)
+```
+
+### Evite fontes unicas
+
+```elixir
+# RUIM: um unico arquivo grande e gargalo
+File.stream!("huge_file.txt") |> Flow.from_enumerable()
+
+# BOM: multiplos arquivos menores
+streams = Enum.map(files, &File.stream!(&1, read_ahead: 100_000))
+Flow.from_enumerables(streams)
+```
+
+### Use ETS para contadores
+
+```elixir
+# Mapas geram muito garbage em contadores grandes
+# ETS e muito mais eficiente para update_counter
+Flow.reduce(fn -> :ets.new(:t, []) end, fn item, ets ->
+  :ets.update_counter(ets, item, {2, 1}, {item, 0})
+  ets
+end)
+```
+
+### Compile patterns binarios
+
+```elixir
+# RUIM: recompila o pattern a cada split
+Flow.flat_map(&String.split(&1, " "))
+
+# BOM: compila uma vez
+pattern = :binary.compile_pattern(" ")
+Flow.flat_map(&String.split(&1, pattern))
+```
+
+---
+
+## 15. Referencia Rapida da API
+
+### Fontes de Dados
+| Funcao | Descricao |
+|--------|-----------|
+| `from_enumerable/2` | Uma fonte enumerable |
+| `from_enumerables/2` | Lista de enumerables |
+| `from_stages/2` | Producers ja rodando |
+| `from_specs/2` | Child specs de producers |
+
+### Mappers (stateless, paralelos)
+| Funcao | Descricao |
+|--------|-----------|
+| `map/2` | Transforma cada elemento |
+| `flat_map/2` | Transforma e achata |
+| `filter/2` | Filtra elementos |
+| `reject/2` | Rejeita elementos |
+| `map_values/2` | Mapeia valores de tuplas |
+| `map_batch/2` | Processa batch inteiro |
+
+### Reducers (stateful, por particao)
+| Funcao | Descricao |
+|--------|-----------|
+| `reduce/3` | Acumula estado |
+| `group_by/3` | Agrupa por chave |
+| `group_by_key/1` | Agrupa tuplas {k, v} |
+| `emit_and_reduce/3` | Emite e reduz simultaneamente |
+| `uniq/1` | Elementos unicos |
+| `uniq_by/2` | Unicos por funcao |
+
+### Emissao e Controle
+| Funcao | Descricao |
+|--------|-----------|
+| `emit/2` | Controla o que emitir (:events, :state, :nothing) |
+| `on_trigger/2` | Callback quando trigger dispara |
+
+### Topologia
+| Funcao | Descricao |
+|--------|-----------|
+| `partition/2` | Nova particao com PartitionDispatcher |
+| `shuffle/2` | Nova camada com DemandDispatcher |
+| `merge/3` | Merge com dispatcher customizado |
+| `departition/5` | Merge resultados de todas as particoes |
+| `take_sort/4` | Top N entre todas as particoes |
+
+### Joins
+| Funcao | Descricao |
+|--------|-----------|
+| `bounded_join/7` | Join de flows finitos |
+| `window_join/8` | Join com janela temporal |
+
+### Execucao
+| Funcao | Descricao |
+|--------|-----------|
+| `Enum.to_list(flow)` | Coleta resultados (blocking) |
+| `run/2` | Executa por side-effects |
+| `stream/2` | Converte para Stream |
+| `start_link/2` | Inicia como processo supervisionado |
+| `into_stages/3` | Inicia com consumers existentes |
+| `into_specs/3` | Inicia com consumer specs |
+| `through_stages/3` | Passa por producer_consumers existentes |
+| `through_specs/3` | Passa por producer_consumer specs |
+
+### Windows
+| Funcao | Descricao |
+|--------|-----------|
+| `Window.global/0` | Janela global (padrao) |
+| `Window.fixed/3` | Janela fixa por event time |
+| `Window.periodic/2` | Janela por processing time |
+| `Window.count/1` | Janela por contagem |
+| `Window.allowed_lateness/3` | Tolerancia a dados atrasados (so fixed) |
+| `Window.trigger/3` | Trigger customizado |
+| `Window.trigger_every/2` | Trigger a cada N eventos |
+| `Window.trigger_periodically/3` | Trigger periodico |
+
+---
+
+## 16. Erros Comuns e Como Evitar
+
+```elixir
+# ERRO: reduce depois de reduce
+flow |> Flow.reduce(...) |> Flow.reduce(...)  # ArgumentError!
+# CORRETO: use on_trigger para transformar entre reducoes
+flow |> Flow.reduce(...) |> Flow.on_trigger(...)
+
+# ERRO: map depois de reduce
+flow |> Flow.reduce(...) |> Flow.map(...)  # ArgumentError!
+# CORRETO: use on_trigger ou partition novamente
+flow |> Flow.reduce(...) |> Flow.partition() |> Flow.map(...)
+
+# ERRO: emit/on_trigger sem reduce
+flow |> Flow.emit(:state)  # ArgumentError!
+# CORRETO: sempre apos reduce
+flow |> Flow.reduce(...) |> Flow.emit(:state)
+
+# ERRO: bounded_join com dados infinitos (vai estourar memoria)
+# CORRETO: use window_join para dados infinitos
+
+# ERRO: uniq_by com dados infinitos sem window (set cresce infinitamente)
+# CORRETO: use uniq_by dentro de uma window
+```
+
+---
+
+## 17. Quando Usar Flow?
+
+### Use Flow quando:
+- Processamento de grandes colecoes (>500 itens)
+- Leitura/processamento de multiplos arquivos
+- Aggregacoes paralelas (contagem, soma, agrupamento)
+- Pipelines ETL
+- Processamento de streams em tempo real com GenStage
+
+### NAO use Flow quando:
+- Colecoes pequenas (<500 itens) - overhead dos processos nao compensa
+- Operacoes estritamente sequenciais - use Stream
+- Logica simples sem necessidade de paralelismo - use Enum
+- Precisa de ordenacao garantida - Flow nao garante ordem

--- a/docs/skills/GenStage.md
+++ b/docs/skills/GenStage.md
@@ -1,0 +1,1245 @@
+# Skill GenStage - Guia Completo para Desenvolvedores Elixir
+
+## O que e GenStage?
+
+GenStage e uma especificacao Elixir para troca de eventos entre **producers** (produtores) e **consumers** (consumidores) com **back-pressure** (contrapressao) automatica. Ele resolve o problema fundamental de: "Como processar dados de forma concorrente sem sobrecarregar o sistema?"
+
+A ideia central: **o consumidor pede dados ao produtor** (modelo pull), nao o produtor empurrando dados para o consumidor (modelo push). Isso garante que nenhum componente do pipeline fique sobrecarregado.
+
+---
+
+## Instalacao
+
+```elixir
+# mix.exs
+defp deps do
+  [
+    {:gen_stage, "~> 1.0"}
+  ]
+end
+```
+
+Requisito: Elixir >= 1.11
+
+---
+
+## Conceitos Fundamentais
+
+### Os 3 Tipos de Stage
+
+```
++------------+       +---------------------+       +------------+
+|  PRODUCER  | ----> | PRODUCER_CONSUMER   | ----> |  CONSUMER  |
+| (Source)   |       | (Transformador)     |       | (Sink)     |
++------------+       +---------------------+       +------------+
+     ^                        ^                          |
+     |                        |                          |
+  Gera eventos         Recebe E emite            Consome eventos
+  sob demanda          eventos                   e pede mais
+```
+
+1. **`:producer`** (source) - Apenas gera eventos. Implementa `handle_demand/2`.
+2. **`:consumer`** (sink) - Apenas consome eventos. Implementa `handle_events/3`.
+3. **`:producer_consumer`** - Recebe eventos, transforma e emite novos. Implementa `handle_events/3`.
+
+### Como funciona o Back-Pressure
+
+```
+Consumer: "Quero 1000 eventos" (max_demand: 1000)
+    |
+    v
+Producer: Envia ate 1000 eventos
+    |
+    v
+Consumer: Processa eventos...
+    Quando demanda cai para 750 (min_demand), pede mais 250
+    |
+    v
+Producer: Envia mais 250
+    ... ciclo continua ...
+```
+
+- `max_demand` - Maximo de eventos solicitados por vez (padrao: 1000)
+- `min_demand` - Limiar para pedir mais eventos (padrao: max_demand * 3/4, ou seja, 750)
+- O consumidor NUNCA recebe mais do que pediu
+- Quando o producer produz em lotes de 100 e max_demand=1000/min_demand=750: apos 3 lotes a demanda cai para 700 (abaixo de 750), entao o consumer pede 300 para voltar a 1000
+
+---
+
+## Padrao 1: Pipeline Basico (Producer -> Consumer)
+
+O caso mais simples: um produtor gera numeros e um consumidor os processa.
+
+```elixir
+defmodule NumberProducer do
+  use GenStage
+
+  def start_link(initial) do
+    GenStage.start_link(__MODULE__, initial, name: __MODULE__)
+  end
+
+  @impl true
+  def init(counter) do
+    {:producer, counter}
+  end
+
+  @impl true
+  def handle_demand(demand, counter) when demand > 0 do
+    # Se counter=3 e demand=2, emite [3, 4] e estado vira 5
+    events = Enum.to_list(counter..(counter + demand - 1))
+    {:noreply, events, counter + demand}
+  end
+end
+
+defmodule NumberConsumer do
+  use GenStage
+
+  def start_link(_opts) do
+    GenStage.start_link(__MODULE__, :ok)
+  end
+
+  @impl true
+  def init(:ok) do
+    # subscribe_to conecta automaticamente ao producer
+    {:consumer, :ok, subscribe_to: [{NumberProducer, max_demand: 10}]}
+  end
+
+  @impl true
+  def handle_events(events, _from, state) do
+    Enum.each(events, fn event ->
+      IO.puts("Processando: #{event}")
+    end)
+
+    # Consumer SEMPRE retorna lista vazia de eventos
+    {:noreply, [], state}
+  end
+end
+```
+
+### Supervision Tree
+
+```elixir
+children = [
+  {NumberProducer, 0},
+  Supervisor.child_spec({NumberConsumer, []}, id: :c1),
+  Supervisor.child_spec({NumberConsumer, []}, id: :c2),
+  Supervisor.child_spec({NumberConsumer, []}, id: :c3),
+  Supervisor.child_spec({NumberConsumer, []}, id: :c4)
+]
+
+# rest_for_one: se o producer reiniciar, consumers tambem reiniciam
+Supervisor.start_link(children, strategy: :rest_for_one)
+```
+
+> **IMPORTANTE**: Use `strategy: :rest_for_one` para que se o producer reiniciar, os consumers tambem reiniciem (eles precisam se reinscrever). Com `:one_for_one`, se o producer A morre, os consumers morrem tambem (perdem a inscricao) e o supervisor pode interpretar como muitas falhas simultaneas.
+
+---
+
+## Padrao 2: Pipeline com Transformacao (Producer -> ProducerConsumer -> Consumer)
+
+Quando voce precisa transformar dados entre a fonte e o destino.
+
+```elixir
+defmodule DataSource do
+  use GenStage
+
+  def start_link(opts) do
+    GenStage.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_opts) do
+    {:producer, :no_state}
+  end
+
+  @impl true
+  def handle_demand(demand, state) do
+    events = fetch_from_database(demand)
+    {:noreply, events, state}
+  end
+
+  defp fetch_from_database(count) do
+    Enum.map(1..count, fn i -> %{id: i, raw_data: "data_#{i}"} end)
+  end
+end
+
+defmodule DataTransformer do
+  use GenStage
+
+  def start_link(_opts) do
+    GenStage.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @impl true
+  def init(:ok) do
+    # producer_consumer tem buffer_size: :infinity por padrao!
+    {:producer_consumer, :ok, subscribe_to: [{DataSource, max_demand: 100}]}
+  end
+
+  @impl true
+  def handle_events(events, _from, state) do
+    transformed =
+      events
+      |> Enum.map(&transform/1)
+      |> Enum.filter(&valid?/1)
+
+    # producer_consumer PODE filtrar: emitir menos eventos do que recebeu
+    {:noreply, transformed, state}
+  end
+
+  defp transform(%{raw_data: data} = event) do
+    Map.put(event, :processed_data, String.upcase(data))
+  end
+
+  defp valid?(%{processed_data: data}), do: String.length(data) > 0
+end
+
+defmodule DataSink do
+  use GenStage
+
+  def start_link(_opts) do
+    GenStage.start_link(__MODULE__, :ok)
+  end
+
+  @impl true
+  def init(:ok) do
+    {:consumer, :ok, subscribe_to: [{DataTransformer, max_demand: 50}]}
+  end
+
+  @impl true
+  def handle_events(events, _from, state) do
+    Enum.each(events, &persist/1)
+    {:noreply, [], state}
+  end
+
+  defp persist(event) do
+    IO.inspect(event, label: "Persistindo")
+  end
+end
+```
+
+> **Anti-pattern**: NAO crie um stage por passo logico do seu dominio. Stages servem para modelar propriedades de runtime (concorrencia, transferencia de dados), NAO organizacao de codigo. Se voce tem 3 passos logicos, considere combina-los em um unico consumer e escalar com multiplas instancias:
+
+```
+                 [Consumer: Step1 + Step2 + Step3]
+                /
+[Producer] ---->[Consumer: Step1 + Step2 + Step3]
+                \
+                 [Consumer: Step1 + Step2 + Step3]
+```
+
+---
+
+## Padrao 3: BroadcastDispatcher (1 Producer -> N Consumers, todos recebem tudo)
+
+Quando TODOS os consumers precisam receber TODOS os eventos (fan-out).
+
+```elixir
+defmodule EventBroadcaster do
+  use GenStage
+
+  def start_link(_opts) do
+    GenStage.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @doc "Envia evento e so retorna apos o despacho"
+  def sync_notify(event, timeout \\ 5000) do
+    GenStage.call(__MODULE__, {:notify, event}, timeout)
+  end
+
+  @impl true
+  def init(:ok) do
+    # BroadcastDispatcher envia para TODOS os consumers
+    # Acumula demanda ate TODOS terem pedido
+    {:producer, {:queue.new(), 0}, dispatcher: GenStage.BroadcastDispatcher}
+  end
+
+  @impl true
+  def handle_call({:notify, event}, from, {queue, pending_demand}) do
+    queue = :queue.in({from, event}, queue)
+    dispatch_events(queue, pending_demand, [])
+  end
+
+  @impl true
+  def handle_demand(incoming_demand, {queue, pending_demand}) do
+    dispatch_events(queue, incoming_demand + pending_demand, [])
+  end
+
+  defp dispatch_events(queue, 0, events) do
+    {:noreply, Enum.reverse(events), {queue, 0}}
+  end
+
+  defp dispatch_events(queue, demand, events) do
+    case :queue.out(queue) do
+      {{:value, {from, event}}, queue} ->
+        GenStage.reply(from, :ok)
+        dispatch_events(queue, demand - 1, [event | events])
+
+      {:empty, queue} ->
+        {:noreply, Enum.reverse(events), {queue, demand}}
+    end
+  end
+end
+```
+
+### Consumer com filtro (selector)
+
+```elixir
+# Consumer que recebe APENAS eventos do tipo :email
+defmodule EmailNotifier do
+  use GenStage
+
+  def start_link(_opts) do
+    GenStage.start_link(__MODULE__, :ok)
+  end
+
+  @impl true
+  def init(:ok) do
+    selector = fn event -> event.type == :email end
+
+    {:consumer, :ok,
+     subscribe_to: [
+       {EventBroadcaster, selector: selector}
+     ]}
+  end
+
+  @impl true
+  def handle_events(events, _from, state) do
+    Enum.each(events, fn event ->
+      IO.puts("Enviando email: #{inspect(event)}")
+    end)
+    {:noreply, [], state}
+  end
+end
+
+# Consumer que recebe TODOS os eventos (auditoria)
+defmodule AuditLogger do
+  use GenStage
+
+  def start_link(_opts) do
+    GenStage.start_link(__MODULE__, :ok)
+  end
+
+  @impl true
+  def init(:ok) do
+    {:consumer, :ok, subscribe_to: [EventBroadcaster]}
+  end
+
+  @impl true
+  def handle_events(events, _from, state) do
+    Enum.each(events, fn event ->
+      IO.puts("[AUDIT] #{inspect(event)}")
+    end)
+    {:noreply, [], state}
+  end
+end
+```
+
+> **Cuidado com o BroadcastDispatcher durante setup**: O primeiro lote de eventos pode ser entregue antes de todos os consumers se inscreverem. Use `demand: :accumulate` no init do producer e chame `GenStage.demand(producer, :forward)` depois que todos os consumers estiverem conectados.
+
+```elixir
+def init(:ok) do
+  {:producer, state, dispatcher: GenStage.BroadcastDispatcher, demand: :accumulate}
+end
+
+# Depois de todos os consumers se inscreverem:
+GenStage.demand(EventBroadcaster, :forward)
+```
+
+---
+
+## Padrao 4: PartitionDispatcher (Roteamento por Chave)
+
+Quando voce precisa rotear eventos para consumers especificos baseado em uma chave. Apenas UM consumer por particao.
+
+```elixir
+defmodule OrderProducer do
+  use GenStage
+
+  def start_link(_opts) do
+    GenStage.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @impl true
+  def init(:ok) do
+    {:producer, {:queue.new(), 0},
+     dispatcher: {
+       GenStage.PartitionDispatcher,
+       partitions: [:standard, :express, :international],
+       hash: fn event ->
+         # Retorna {evento, nome_da_particao}
+         {event, event.shipping_type}
+       end
+     }}
+  end
+
+  # API publica
+  def new_order(order) do
+    GenStage.cast(__MODULE__, {:order, order})
+  end
+
+  @impl true
+  def handle_cast({:order, order}, {queue, demand}) do
+    queue = :queue.in(order, queue)
+    dispatch(queue, demand, [])
+  end
+
+  @impl true
+  def handle_demand(incoming, {queue, demand}) do
+    dispatch(queue, incoming + demand, [])
+  end
+
+  defp dispatch(queue, 0, events),
+    do: {:noreply, Enum.reverse(events), {queue, 0}}
+
+  defp dispatch(queue, demand, events) do
+    case :queue.out(queue) do
+      {{:value, order}, queue} ->
+        dispatch(queue, demand - 1, [order | events])
+      {:empty, queue} ->
+        {:noreply, Enum.reverse(events), {queue, demand}}
+    end
+  end
+end
+
+# Um consumer POR particao (obrigatorio)
+defmodule OrderProcessor do
+  use GenStage
+
+  def start_link(partition) do
+    GenStage.start_link(__MODULE__, partition)
+  end
+
+  @impl true
+  def init(partition) do
+    {:consumer, partition,
+     subscribe_to: [
+       {OrderProducer, partition: partition, max_demand: 20}
+     ]}
+  end
+
+  @impl true
+  def handle_events(orders, _from, partition) do
+    Enum.each(orders, fn order ->
+      IO.puts("[#{partition}] Processando pedido ##{order.id}")
+    end)
+    {:noreply, [], partition}
+  end
+end
+```
+
+Supervision:
+
+```elixir
+children = [
+  {OrderProducer, []},
+  Supervisor.child_spec({OrderProcessor, :standard}, id: :proc_standard),
+  Supervisor.child_spec({OrderProcessor, :express}, id: :proc_express),
+  Supervisor.child_spec({OrderProcessor, :international}, id: :proc_international)
+]
+
+Supervisor.start_link(children, strategy: :rest_for_one)
+```
+
+### Particoes com inteiros e hash automatico
+
+```elixir
+# Particoes 0, 1, 2, 3 com hash automatico via :erlang.phash2
+{:producer, state,
+ dispatcher: {GenStage.PartitionDispatcher, partitions: 0..3}}
+
+# Inscricao:
+{:consumer, state, subscribe_to: [{MyProducer, partition: 0}]}
+```
+
+> **Atencao**: O PartitionDispatcher assume distribuicao uniforme entre particoes. Se os dados sao muito desiguais por longos periodos, particoes ocupadas vao acumular no buffer enquanto particoes ociosas ficam paradas. Isso e aceitavel para picos temporarios, mas problematico para desbalanceamento constante.
+
+### A funcao hash pode descartar eventos
+
+```elixir
+hash: fn event ->
+  case event.priority do
+    :low -> :none  # Evento descartado, nao vai para nenhuma particao
+    _ -> {event, event.region}
+  end
+end
+```
+
+---
+
+## Padrao 5: Rate Limiter (Controle Manual de Demanda)
+
+Quando voce precisa controlar a taxa de processamento (ex: API com rate limit).
+
+A chave e retornar `{:manual, state}` de `handle_subscribe/4` e usar `GenStage.ask/3` para controlar quando pedir mais eventos.
+
+```elixir
+defmodule RateLimitedConsumer do
+  use GenStage
+
+  def start_link(opts) do
+    GenStage.start_link(__MODULE__, opts)
+  end
+
+  @impl true
+  def init(_opts) do
+    # Estado: mapa de producers com seus pending/interval
+    {:consumer, %{}}
+  end
+
+  @impl true
+  def handle_subscribe(:producer, opts, from, producers) do
+    # Configura quantos eventos por intervalo
+    pending = opts[:max_demand] || 1000
+    interval = opts[:interval] || 5000
+
+    producers = Map.put(producers, from, {pending, interval})
+    producers = ask_and_schedule(producers, from)
+
+    # :manual = EU controlo quando pedir mais eventos
+    {:manual, producers}
+  end
+
+  @impl true
+  def handle_cancel(_, from, producers) do
+    {:noreply, [], Map.delete(producers, from)}
+  end
+
+  @impl true
+  def handle_events(events, from, producers) do
+    # Acumula pending para proxima janela de tempo
+    producers =
+      Map.update!(producers, from, fn {pending, interval} ->
+        {pending + length(events), interval}
+      end)
+
+    # Processa os eventos
+    Enum.each(events, &IO.inspect/1)
+
+    {:noreply, [], producers}
+  end
+
+  @impl true
+  def handle_info({:ask, from}, producers) do
+    {:noreply, [], ask_and_schedule(producers, from)}
+  end
+
+  defp ask_and_schedule(producers, from) do
+    case producers do
+      %{^from => {pending, interval}} ->
+        GenStage.ask(from, pending)
+        Process.send_after(self(), {:ask, from}, interval)
+        Map.put(producers, from, {0, interval})
+
+      _ ->
+        producers
+    end
+  end
+end
+```
+
+### Uso
+
+```elixir
+{:ok, producer} = GenStage.start_link(MyProducer, 0)
+{:ok, consumer} = GenStage.start_link(RateLimitedConsumer, :ok)
+
+# 10 eventos a cada 2 segundos
+GenStage.sync_subscribe(consumer, to: producer, max_demand: 10, interval: 2000)
+```
+
+---
+
+## Padrao 6: ConsumerSupervisor (1 Processo por Evento)
+
+Quando cada evento precisa ser processado por um processo filho separado. O `max_demand` age como limite de concorrencia (como um pool).
+
+```elixir
+defmodule JobProducer do
+  use GenStage
+
+  def start_link(_opts) do
+    GenStage.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  def enqueue(job) do
+    GenStage.cast(__MODULE__, {:enqueue, job})
+  end
+
+  @impl true
+  def init(:ok) do
+    {:producer, {:queue.new(), 0}}
+  end
+
+  @impl true
+  def handle_cast({:enqueue, job}, {queue, demand}) do
+    queue = :queue.in(job, queue)
+    dispatch_jobs(queue, demand, [])
+  end
+
+  @impl true
+  def handle_demand(incoming_demand, {queue, demand}) do
+    dispatch_jobs(queue, incoming_demand + demand, [])
+  end
+
+  defp dispatch_jobs(queue, 0, events) do
+    {:noreply, Enum.reverse(events), {queue, 0}}
+  end
+
+  defp dispatch_jobs(queue, demand, events) do
+    case :queue.out(queue) do
+      {{:value, job}, queue} ->
+        dispatch_jobs(queue, demand - 1, [job | events])
+      {:empty, queue} ->
+        {:noreply, Enum.reverse(events), {queue, demand}}
+    end
+  end
+end
+
+defmodule JobWorkerSupervisor do
+  use ConsumerSupervisor
+
+  def start_link(_opts) do
+    ConsumerSupervisor.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @impl true
+  def init(:ok) do
+    # Filhos DEVEM ter restart: :temporary ou :transient
+    children = [
+      %{
+        id: JobWorker,
+        start: {JobWorker, :start_link, []},
+        restart: :temporary
+      }
+    ]
+
+    opts = [
+      strategy: :one_for_one,
+      subscribe_to: [{JobProducer, max_demand: 50}]
+    ]
+
+    ConsumerSupervisor.init(children, opts)
+  end
+end
+
+defmodule JobWorker do
+  def start_link(job) do
+    Task.start_link(fn ->
+      IO.puts("Processando job: #{inspect(job)}")
+      Process.sleep(Enum.random(100..1000))
+      IO.puts("Job concluido: #{inspect(job)}")
+    end)
+  end
+end
+```
+
+> **Nota**: O `max_demand` no ConsumerSupervisor funciona como limite de concorrencia. Com `max_demand: 50`, no maximo 50 workers rodam simultaneamente. A media de filhos simultaneos e `(max_demand + min_demand) / 2`.
+
+---
+
+## Padrao 7: Producer com Buffer Automatico (Eventos Asincronos)
+
+Quando eventos chegam de forma assincrona (webhooks, filas externas, etc.) e nao sob demanda.
+
+```elixir
+defmodule AsyncProducer do
+  use GenStage
+
+  def start_link(_opts) do
+    GenStage.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  # API publica - eventos chegam a qualquer momento
+  def push(events) when is_list(events) do
+    GenStage.cast(__MODULE__, {:push, events})
+  end
+
+  @impl true
+  def init(:ok) do
+    # buffer_size: quantos eventos armazenar quando nao ha demanda
+    # buffer_keep: :last descarta os mais antigos quando excede, :first descarta os novos
+    {:producer, :ok, buffer_size: 50_000, buffer_keep: :last}
+  end
+
+  @impl true
+  def handle_demand(_demand, state) do
+    # Nao temos eventos sob demanda - eles chegam via push/1
+    {:noreply, [], state}
+  end
+
+  @impl true
+  def handle_cast({:push, events}, state) do
+    # Eventos sao automaticamente bufferizados se nao houver demanda
+    # Se o buffer exceder buffer_size, um log de erro e emitido
+    {:noreply, events, state}
+  end
+end
+```
+
+### Sobre o Buffer Automatico
+
+- **`:producer`**: `buffer_size` padrao = `10_000`
+- **`:producer_consumer`**: `buffer_size` padrao = `:infinity` (cuidado com memoria!)
+- Quando o buffer excede o tamanho, eventos sao descartados e um log e emitido
+- Customize o log implementando `format_discarded/2`:
+
+```elixir
+@impl true
+def format_discarded(discarded_count, current_buffer_size) do
+  "Descartados #{discarded_count} eventos. Buffer atual: #{current_buffer_size}"
+end
+```
+
+---
+
+## Padrao 8: Inscricao Dinamica (subscribe em runtime)
+
+Quando voce nao sabe em tempo de compilacao quais producers existem.
+
+```elixir
+defmodule DynamicConsumer do
+  use GenStage
+
+  def start_link(opts) do
+    GenStage.start_link(__MODULE__, opts)
+  end
+
+  def subscribe_to_producer(consumer, producer, opts \\ []) do
+    # Retorna {:ok, subscription_tag} ou {:error, reason}
+    GenStage.sync_subscribe(consumer, [{:to, producer} | opts])
+  end
+
+  def unsubscribe(consumer, subscription_tag, reason \\ :normal) do
+    GenStage.cancel({subscription_tag, consumer}, reason)
+  end
+
+  @impl true
+  def init(_opts) do
+    # Inicia SEM inscricoes
+    {:consumer, %{}}
+  end
+
+  @impl true
+  def handle_subscribe(:producer, _opts, from, state) do
+    IO.puts("Inscrito em: #{inspect(from)}")
+    {:automatic, state}
+  end
+
+  @impl true
+  def handle_cancel({:cancel, _}, from, state) do
+    IO.puts("Desinscrito de: #{inspect(from)}")
+    {:noreply, [], state}
+  end
+
+  @impl true
+  def handle_events(events, {producer_pid, _ref}, state) do
+    IO.puts("#{length(events)} eventos de #{inspect(producer_pid)}")
+    {:noreply, [], state}
+  end
+end
+```
+
+### sync_subscribe vs async_subscribe
+
+```elixir
+# sync_subscribe: bloqueia ate o producer confirmar a inscricao
+# Retorna {:ok, tag} ou {:error, reason}
+{:ok, tag} = GenStage.sync_subscribe(consumer, to: producer, max_demand: 100)
+
+# async_subscribe: nao bloqueia, inscricao acontece eventualmente
+# Retorna {:ok, tag} imediatamente
+{:ok, tag} = GenStage.async_subscribe(consumer, to: producer)
+```
+
+### Tipos de Cancelamento
+
+```elixir
+GenStage.sync_subscribe(consumer,
+  to: producer,
+  cancel: :permanent   # (padrao) consumer para se producer morrer
+  # cancel: :transient # consumer para so se producer morrer com erro
+  # cancel: :temporary # consumer NUNCA para por causa do producer
+)
+```
+
+---
+
+## Padrao 9: Usando GenStage com Streams do Elixir
+
+Para integrar GenStage com o ecossistema de Streams (util para testes e scripts).
+
+```elixir
+# Criar um producer a partir de um Enumerable
+{:ok, producer} = GenStage.from_enumerable(1..1_000_000)
+
+# Criar um stream a partir de producers (consome como consumer)
+GenStage.stream([{producer, max_demand: 100}])
+|> Stream.map(&(&1 * 2))
+|> Stream.take(10)
+|> Enum.to_list()
+# => [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+```
+
+### Util para testes
+
+```elixir
+test "valida transformacao do pipeline" do
+  {:ok, producer} = GenStage.from_enumerable([
+    %{id: 1, total: 100},
+    %{id: 2, total: -10},    # invalido
+    %{id: 3, total: 200}
+  ])
+
+  {:ok, transformer} = GenStage.start_link(MyTransformer, :ok)
+  GenStage.sync_subscribe(transformer, to: producer, max_demand: 10)
+
+  results =
+    GenStage.stream([{transformer, max_demand: 10}])
+    |> Enum.to_list()
+
+  assert length(results) == 2
+end
+```
+
+---
+
+## Padrao 10: Controle de Demanda (accumulate/forward)
+
+Quando voce precisa acumular demanda antes de comecar a processar (ex: esperar que todos os consumers se inscrevam, ou esperar conexao com banco).
+
+```elixir
+defmodule DatabaseProducer do
+  use GenStage
+
+  def start_link(_opts) do
+    GenStage.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  # Chamado quando a conexao com o banco estiver pronta
+  def start_producing do
+    GenStage.demand(__MODULE__, :forward)
+  end
+
+  # Consultar o modo atual
+  def demand_mode do
+    GenStage.demand(__MODULE__)
+  end
+
+  @impl true
+  def init(:ok) do
+    # :accumulate = acumula demanda sem emitir eventos
+    {:producer, :not_connected, demand: :accumulate}
+  end
+
+  @impl true
+  def handle_demand(demand, state) do
+    # So e chamado quando o modo e :forward
+    events = fetch_from_db(demand)
+    {:noreply, events, state}
+  end
+
+  defp fetch_from_db(count) do
+    Enum.to_list(1..count)
+  end
+end
+```
+
+---
+
+## Referencia Completa de Callbacks
+
+### Obrigatorios
+
+| Callback | Tipo | Assinatura | Descricao |
+|----------|------|------------|-----------|
+| `init/1` | Todos | `init(args)` | Retorna `{:producer, state, opts}`, `{:consumer, state, opts}` ou `{:producer_consumer, state, opts}`. Tambem aceita `:ignore` ou `{:stop, reason}` |
+| `handle_demand/2` | Producer | `handle_demand(demand, state)` | Recebe demanda (sempre > 0). Retorna `{:noreply, events, new_state}` |
+| `handle_events/3` | Consumer/PC | `handle_events(events, from, state)` | Recebe lista de eventos. `from` e `{producer_pid, subscription_tag}` |
+
+### Opcionais
+
+| Callback | Assinatura | Descricao |
+|----------|------------|-----------|
+| `handle_subscribe/4` | `handle_subscribe(:producer\|:consumer, opts, from, state)` | Controla modo da inscricao. Retorna `{:automatic, state}` ou `{:manual, state}` |
+| `handle_cancel/3` | `handle_cancel(reason, from, state)` | Reage a cancelamento. `reason` e `{:cancel, _}`, `{:down, _}`, etc. |
+| `handle_call/3` | `handle_call(request, from, state)` | Chamadas sincronas. Pode retornar `{:reply, reply, events, state}` |
+| `handle_cast/2` | `handle_cast(request, state)` | Mensagens assincronas |
+| `handle_info/2` | `handle_info(msg, state)` | Mensagens genericas |
+| `terminate/2` | `terminate(reason, state)` | Limpeza ao parar |
+| `format_status/2` | `format_status(reason, [pdict, state])` | Formata status do processo para debug |
+| `format_discarded/2` | `format_discarded(discarded, buffered)` | Customiza mensagem de log quando buffer excede |
+
+### Retornos Possiveis
+
+```elixir
+# De handle_demand, handle_events, handle_cast, handle_info:
+{:noreply, events, new_state}
+{:noreply, events, new_state, :hibernate}
+{:stop, reason, new_state}
+
+# De handle_call (adiciona opcao de reply):
+{:reply, reply, events, new_state}
+{:reply, reply, events, new_state, :hibernate}
+{:noreply, events, new_state}
+{:stop, reason, reply, new_state}
+{:stop, reason, new_state}
+
+# De handle_subscribe:
+{:automatic, new_state}   # demanda automatica (padrao)
+{:manual, new_state}      # voce controla via GenStage.ask/3
+
+# De handle_cancel:
+{:noreply, events, new_state}
+```
+
+> **Nota**: Em TODOS os callbacks, o campo `events` DEVE ser `[]` para consumers. Producers e producer_consumers podem emitir eventos.
+
+---
+
+## Referencia Completa de Dispatchers
+
+### DemandDispatcher (padrao)
+
+Envia eventos para o consumer com maior demanda pendente. Ordenacao FIFO.
+
+```elixir
+{:producer, state}  # usa DemandDispatcher por padrao
+
+# Ou explicitamente com opcoes:
+{:producer, state,
+ dispatcher: {GenStage.DemandDispatcher,
+   shuffle_demands_on_first_dispatch: true,  # evita sobrecarregar o 1o consumer
+   max_demand: 1000                           # emite warning se consumer pedir mais
+ }}
+```
+
+> **Regra**: Todos os consumers de um mesmo producer com DemandDispatcher devem ter o MESMO `max_demand`. Caso contrario, consumers "gulosos" (com max_demand maior) recebem mais eventos.
+
+### BroadcastDispatcher
+
+Envia TODOS os eventos para TODOS os consumers. Aguarda a demanda minima de todos antes de enviar.
+
+```elixir
+{:producer, state, dispatcher: GenStage.BroadcastDispatcher}
+
+# Consumer com filtro:
+{:consumer, state, subscribe_to: [
+  {producer, selector: fn event -> event.important? end}
+]}
+```
+
+> **Regra**: Um mesmo processo NAO pode se inscrever duas vezes. O BroadcastDispatcher rejeita com `:already_subscribed`.
+
+### PartitionDispatcher
+
+Roteia eventos para particoes fixas. Exatamente 1 consumer por particao.
+
+```elixir
+{:producer, state,
+ dispatcher: {GenStage.PartitionDispatcher,
+   partitions: [:odd, :even],  # ou inteiro: partitions: 4  (gera 0..3)
+   hash: fn event ->
+     case rem(event, 2) do
+       0 -> {event, :even}
+       1 -> {event, :odd}
+     end
+   end
+ }}
+
+# Consumer DEVE especificar particao:
+{:consumer, state, subscribe_to: [{producer, partition: :even}]}
+```
+
+> **Regras**:
+> - Se `:partitions` usa nomes nao-inteiros, voce DEVE fornecer `:hash`
+> - A funcao hash pode retornar `:none` para descartar o evento
+> - Apenas 1 consumer por particao (erro se tentar 2)
+
+---
+
+## Funcoes da API Publica
+
+### Ciclo de Vida
+
+```elixir
+GenStage.start_link(module, args, opts)     # Inicia com link ao processo pai
+GenStage.start(module, args, opts)          # Inicia sem link
+GenStage.stop(stage, reason \\ :normal, timeout \\ :infinity)
+```
+
+### Inscricao
+
+```elixir
+GenStage.sync_subscribe(stage, opts)                        # Bloqueante
+GenStage.async_subscribe(stage, opts)                       # Nao-bloqueante
+GenStage.sync_resubscribe(stage, tag, reason, to, opts)     # Cancela e reinscreve
+GenStage.async_resubscribe(stage, tag, reason, opts)        # Idem, async
+GenStage.cancel({tag, stage}, reason)                       # Cancela inscricao
+```
+
+### Controle de Demanda
+
+```elixir
+GenStage.ask(from, demand)                  # Pede eventos (so modo :manual)
+GenStage.demand(stage)                      # Consulta modo (:forward ou :accumulate)
+GenStage.demand(stage, :forward)            # Ativa envio de eventos
+GenStage.demand(stage, :accumulate)         # Pausa envio, acumula demanda
+```
+
+### Comunicacao (compativel com GenServer)
+
+```elixir
+GenStage.call(stage, request, timeout \\ 5000)
+GenStage.cast(stage, request)
+GenStage.reply(from, reply)
+GenStage.sync_info(stage, msg, timeout \\ 5000)  # Enfileira info (respeita ordem com eventos)
+GenStage.async_info(stage, msg)                   # Idem, async
+```
+
+### Utilitarios
+
+```elixir
+GenStage.from_enumerable(enumerable, opts \\ [])  # Cria producer de enumerable
+GenStage.stream(subscriptions, opts \\ [])          # Cria stream de producers
+GenStage.estimate_buffered_count(stage, timeout \\ 5000)  # Tamanho estimado do buffer
+```
+
+---
+
+## Boas Praticas e Armadilhas
+
+### FACA
+
+1. **Use GenStage para concorrencia e transferencia de dados**, nao para organizar codigo ou modelar dominios
+2. **Combine passos logicos no mesmo stage** quando possivel - cada stage adiciona overhead de processo e mensagens
+3. **Escale com multiplos consumers** em vez de mais stages intermediarios
+4. **Use `Task.async_stream/2`** para paralelismo simples antes de recorrer ao GenStage
+5. **Configure `max_demand` igual em todos os consumers** de um mesmo producer com DemandDispatcher
+6. **Use `strategy: :rest_for_one`** no Supervisor
+7. **Use `:subscribe_to` no init** ao inves de subscribe manual - garante re-inscricao apos crashes
+8. **Trate `handle_cancel/3`** para limpar estado quando um producer cai
+
+### NAO FACA
+
+1. **Nao crie pipelines longos** com um stage por passo logico
+2. **Nao use `max_demand: 1`** exceto para debug - mata performance (sem batching)
+3. **Nao misture consumers com `max_demand` diferentes** no DemandDispatcher
+4. **Nao esqueça que `producer_consumer` tem `buffer_size: :infinity`** por padrao
+5. **Nao ignore o buffer** - monitore com `GenStage.estimate_buffered_count/2`
+6. **Nao faca trabalho assincrono em `handle_events/3`** com modo `:automatic` - a demanda e enviada logo apos o retorno; se precisa de async, use modo `:manual`
+
+### Quando usar GenStage vs Alternativas
+
+| Cenario | Solucao |
+|---------|---------|
+| Paralelismo simples sobre dados em memoria | `Task.async_stream/2` |
+| Pipeline com back-pressure customizado | **GenStage** |
+| Pipeline com janelas/reducoes/particionamento | **Flow** (construido sobre GenStage) |
+| Ingestao de dados (Kafka, SQS, RabbitMQ) | **Broadway** (construido sobre GenStage) |
+| Pub/sub simples | `Phoenix.PubSub` ou `Registry` |
+
+---
+
+## Protocolo de Mensagens (Avancado)
+
+GenStage usa um protocolo de mensagens interno para comunicacao entre stages. Util se voce precisa implementar stages customizados ou debugar:
+
+### Consumer -> Producer
+
+```elixir
+# Inscricao
+{:"$gen_producer", {consumer_pid, subscription_tag}, {:subscribe, current, options}}
+
+# Cancelamento
+{:"$gen_producer", {consumer_pid, subscription_tag}, {:cancel, reason}}
+
+# Pedido de demanda
+{:"$gen_producer", {consumer_pid, subscription_tag}, {:ask, demand}}
+```
+
+### Producer -> Consumer
+
+```elixir
+# Cancelamento (confirmacao ou iniciado pelo producer)
+{:"$gen_consumer", {producer_pid, subscription_tag}, {:cancel, reason}}
+
+# Envio de eventos (lista nao-vazia)
+{:"$gen_consumer", {producer_pid, subscription_tag}, events}
+```
+
+> Ao receber inscricao, o producer DEVE monitorar o consumer. O consumer DEVE monitorar o producer ANTES de enviar a inscricao.
+
+---
+
+## Exemplo Completo: Sistema de Processamento de Pedidos
+
+Exemplo realista com producer assincrono, validacao e persistencia em batch:
+
+```elixir
+# lib/my_app/pipeline/order_producer.ex
+defmodule MyApp.Pipeline.OrderProducer do
+  use GenStage
+
+  def start_link(_opts) do
+    GenStage.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  def new_order(order) do
+    GenStage.cast(__MODULE__, {:new_order, order})
+  end
+
+  @impl true
+  def init(:ok) do
+    {:producer, {:queue.new(), 0}, buffer_size: 10_000}
+  end
+
+  @impl true
+  def handle_cast({:new_order, order}, {queue, demand}) do
+    queue = :queue.in(order, queue)
+    dispatch(queue, demand, [])
+  end
+
+  @impl true
+  def handle_demand(incoming, {queue, demand}) do
+    dispatch(queue, incoming + demand, [])
+  end
+
+  defp dispatch(queue, 0, events),
+    do: {:noreply, Enum.reverse(events), {queue, 0}}
+
+  defp dispatch(queue, demand, events) do
+    case :queue.out(queue) do
+      {{:value, order}, queue} ->
+        dispatch(queue, demand - 1, [order | events])
+      {:empty, queue} ->
+        {:noreply, Enum.reverse(events), {queue, demand}}
+    end
+  end
+end
+
+# lib/my_app/pipeline/order_consumer.ex
+defmodule MyApp.Pipeline.OrderConsumer do
+  use GenStage
+
+  def start_link(_opts) do
+    GenStage.start_link(__MODULE__, :ok)
+  end
+
+  @impl true
+  def init(:ok) do
+    {:consumer, :ok,
+     subscribe_to: [{MyApp.Pipeline.OrderProducer, max_demand: 50}]}
+  end
+
+  @impl true
+  def handle_events(orders, _from, state) do
+    orders
+    |> Enum.map(&validate/1)
+    |> Enum.filter(&match?({:ok, _}, &1))
+    |> Enum.map(fn {:ok, order} -> order end)
+    |> persist_batch()
+
+    {:noreply, [], state}
+  end
+
+  defp validate(order) do
+    cond do
+      is_nil(order.customer_id) -> {:error, :missing_customer}
+      order.total <= 0 -> {:error, :invalid_total}
+      true -> {:ok, Map.put(order, :validated_at, DateTime.utc_now())}
+    end
+  end
+
+  defp persist_batch([]), do: :ok
+  defp persist_batch(orders) do
+    entries = Enum.map(orders, fn order ->
+      %{
+        customer_id: order.customer_id,
+        total: order.total,
+        validated_at: order.validated_at,
+        inserted_at: DateTime.utc_now()
+      }
+    end)
+
+    MyApp.Repo.insert_all("orders", entries)
+  end
+end
+
+# lib/my_app/pipeline/supervisor.ex
+defmodule MyApp.Pipeline.Supervisor do
+  use Supervisor
+
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_opts) do
+    children = [
+      MyApp.Pipeline.OrderProducer,
+      # 4 consumers processando em paralelo
+      Supervisor.child_spec({MyApp.Pipeline.OrderConsumer, []}, id: :consumer_1),
+      Supervisor.child_spec({MyApp.Pipeline.OrderConsumer, []}, id: :consumer_2),
+      Supervisor.child_spec({MyApp.Pipeline.OrderConsumer, []}, id: :consumer_3),
+      Supervisor.child_spec({MyApp.Pipeline.OrderConsumer, []}, id: :consumer_4)
+    ]
+
+    Supervisor.init(children, strategy: :rest_for_one)
+  end
+end
+```
+
+### Uso
+
+```elixir
+# Em qualquer parte da aplicacao:
+MyApp.Pipeline.OrderProducer.new_order(%{
+  customer_id: 42,
+  total: 99.90,
+  items: ["item_a", "item_b"]
+})
+```
+
+---
+
+## Diagrama de Decisao: Qual Dispatcher Usar?
+
+```
+Todos os consumers precisam de todos os eventos?
+  |
+  |-- SIM --> BroadcastDispatcher
+  |            |
+  |            +-- Cada consumer quer apenas um subconjunto?
+  |                  |-- SIM --> Use :selector na inscricao
+  |                  |-- NAO --> Inscricao simples
+  |
+  |-- NAO --> Eventos devem ir para consumers especificos por chave?
+               |
+               |-- SIM --> PartitionDispatcher
+               |            (defina :hash e :partitions)
+               |
+               |-- NAO --> DemandDispatcher (padrao)
+                            (distribuicao por demanda, tipo round-robin)
+```
+
+---
+
+## Checklist para Implementacao
+
+Ao criar um pipeline GenStage, verifique:
+
+- [ ] Cada stage tem `use GenStage` ou `use ConsumerSupervisor`
+- [ ] Producers implementam `handle_demand/2`
+- [ ] Consumers/ProducerConsumers implementam `handle_events/3`
+- [ ] Consumers retornam `[]` como lista de eventos
+- [ ] `max_demand` esta configurado adequadamente (nao muito alto, nao muito baixo)
+- [ ] Consumers do mesmo producer com DemandDispatcher tem o mesmo `max_demand`
+- [ ] `buffer_size` esta configurado para producers que recebem eventos de forma assincrona
+- [ ] `buffer_size` de `producer_consumer` esta explicitamente definido (padrao e `:infinity`)
+- [ ] Supervision tree usa `strategy: :rest_for_one`
+- [ ] Stages estao na ordem correta na supervision tree (producer primeiro)
+- [ ] `subscribe_to` esta no `init/1` (nao fazendo subscribe manual) para auto-reinscricao
+- [ ] Se usando BroadcastDispatcher, considerou `demand: :accumulate` durante setup
+- [ ] Se fazendo trabalho async, usando modo `:manual` com `GenStage.ask/3`
+- [ ] Voce considerou se `Task.async_stream/2` seria suficiente para seu caso

--- a/mix.lock
+++ b/mix.lock
@@ -6,4 +6,5 @@
   "file_system": {:hex, :file_system, "1.1.0", "08d232062284546c6c34426997dd7ef6ec9f8bbd090eb91780283c9016840e8f", [:mix], [], "hexpm", "bfcf81244f416871f2a2e15c1b515287faa5db9c6bcf290222206d120b3d43f6"},
   "jason": {:hex, :jason, "1.4.4", "b9226785a9aa77b6857ca22832cffa5d5011a667207eb2a0ad56adb5db443b8a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b"},
   "mix_test_watch": {:hex, :mix_test_watch, "1.3.0", "2ffc9f72b0d1f4ecf0ce97b044e0e3c607c3b4dc21d6228365e8bc7c2856dc77", [:mix], [{:file_system, "~> 0.2 or ~> 1.0", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm", "f9e5edca976857ffac78632e635750d158df14ee2d6185a15013844af7570ffe"},
+  "telemetry": {:hex, :telemetry, "1.3.0", "fedebbae410d715cf8e7062c96a1ef32ec22e764197f70cda73d82778d61e7a2", [:rebar3], [], "hexpm", "7015fc8919dbe63764f4b4b87a95b7c0996bd539e0d499be6ec9d7f3875b79e6"},
 }


### PR DESCRIPTION
## Summary

- **Decouple Use Cases from concrete Agents**: All 8 use cases now receive the repository module via `opts[:repository]` with `@default_repository` fallback, enabling testability with mocks/stubs and future repository swaps (e.g., Ecto)
- **Decouple GenServers from Agent init**: Organization and Simulation GenServers receive repository module via opts, propagate it to use cases via `enrich_opts/2`
- **Extract shared EventEmitter**: Replaces duplicated `emit_event/3` + `try/rescue UndefinedFunctionError` pattern in 3 use cases with `KanbanVisionApi.Usecase.EventEmitter.emit/4`
- **Add `:telemetry ~> 1.0`** as explicit dependency (removes compile warnings and runtime rescue hack)
- **Fix typespecs**: `List.t()` -> `[ConcreteType.t()]`, `Integer.t()` -> `non_neg_integer()`, `DateTime` -> `DateTime.t()`, `struct()` -> concrete types in Ports
- **Clean up domain entities**: Remove unnecessary intermediate variables in 7 factory functions
- **Fix API contract**: `GetSimulationByOrgAndName` returns `{:ok, simulation}` instead of artificial `{:ok, [simulation]}` wrapping
- **Fix test warnings**: Prefix unused variables with underscore

## Test plan

- [x] `mix test` — 49 tests, 0 failures, 0 warnings
- [x] `mix credo` — 0 issues
- [x] `mix format` — clean
- [ ] Verify CI passes (credo + coveralls + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)