### PR TITLE
chore: document and wire architecture foundations

### DIFF
--- a/.codex/skills/adr/SKILL.md
+++ b/.codex/skills/adr/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: adr
+description: >
+  Use when creating, updating, reviewing, or planning Architectural Decision
+  Records in this repository. Covers the local `adr/` convention, Nygard-style
+  ADR structure, numbering, relations between ADRs, and how to record phased
+  architecture decisions without mixing them with implementation work.
+---
+
+# ADR Skill
+
+Use this skill when the user wants to register, revise, or assess
+architectural decisions for this repository.
+
+## First Step
+
+Read `adr/README.md` and any ADRs directly related to the requested decision
+before writing a new one.
+
+## Local Convention
+
+- ADR files live in `adr/`.
+- Use file names in the form `NNNN-short-kebab-case-title.md`.
+- Keep the `adr/README.md` index updated when adding a new ADR.
+- Use Nygard-style sections: `Status`, `Context`, `Decision`, and
+  `Consequences`.
+- It is acceptable in this repository to add an `Execution Plan` section when a
+  decision will be implemented incrementally.
+
+## When To Create vs Update
+
+- Create a new ADR when the decision is materially new, supersedes an older
+  one, or defines a new phase of architectural direction.
+- Update an existing ADR when you are only clarifying wording, status, or
+  execution progress without changing the actual decision.
+- If the new document narrows, replaces, or extends an earlier decision, add
+  `Related` or `Supersedes` metadata explicitly.
+
+## Writing Rules
+
+- Capture one primary decision per ADR.
+- Separate decision from implementation. Record the chosen direction and plan,
+  not code-level patch details.
+- State clearly whether the ADR is `planned`, `accepted`, `superseded`, or
+  another explicit status.
+- Keep the context specific to this repository: CQS, clean domain boundaries,
+  hexagonal architecture, in-memory persistence now, and prevalence-readiness
+  later when relevant.
+- When the decision spans multiple iterations, describe phases in priority
+  order and mark each phase status explicitly.
+
+## Expected Shape
+
+Most ADRs in this repository should include:
+
+- Title with ADR number.
+- Metadata lines for `Status`, `Date`, and optionally `Related` or
+  `Supersedes`.
+- `Context`
+- `Decision`
+- `Consequences`
+- `Execution Plan` when the work is phased
+- `Notes` only when needed
+
+## Review Checklist
+
+Before finishing, verify:
+
+- The ADR explains why the decision matters architecturally.
+- The decision is distinct from the implementation mechanics.
+- Terminology matches the project direction; for example, prefer `CQS` over
+  `CQRS` unless a true CQRS decision is being introduced.
+- References to earlier ADRs are accurate.
+- The file name, title, and index entry all match.
+
+## References
+
+If needed, read:
+
+- `adr/README.md`
+- the directly related ADR files in `adr/`

--- a/.codex/skills/adr/agents/openai.yaml
+++ b/.codex/skills/adr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "ADR"
+  short_description: "Architectural decision record guidance"
+  default_prompt: "Use $adr to create or update an ADR for this repository."

--- a/.codex/skills/clean-hexagonal-architecture/SKILL.md
+++ b/.codex/skills/clean-hexagonal-architecture/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: clean-hexagonal-architecture
+description: >
+  Use when creating, reviewing, or refactoring code to align this repository
+  with Clean Architecture, Hexagonal Architecture, and Screaming Architecture.
+  Focuses on keeping the domain clean, enforcing inward dependencies, defining
+  explicit ports and adapters, and making use cases the primary organizing
+  structure instead of frameworks or transport concerns.
+---
+
+# Clean Hexagonal Architecture
+
+Use this skill when the user wants to create or refactor code so the repository
+stays aligned with a clean domain model, explicit use cases, and ports/adapters
+boundaries.
+
+## Primary Goal
+
+Favor architecture that makes the business use cases obvious from the codebase.
+Frameworks, HTTP, Agents, GenServers, and persistence are delivery details and
+must stay at the edge.
+
+## Core Rules
+
+- Keep `apps/kanban_domain` framework-free and infrastructure-free.
+- Put business operations in explicit use case modules under `apps/usecase`.
+- Follow CQS: each use case entrypoint accepts either a Command or a Query DTO.
+- Define ports at the boundary of the core; implement adapters in `apps/persistence`
+  or `apps/web_api`.
+- Make dependencies point inward: adapters depend on ports and use cases, never
+  the reverse.
+- Treat Plug, Bandit, Agent, and GenServer as mechanisms, not the architecture.
+- Organizers and controllers translate input and output; they do not hold
+  business rules.
+
+## Repository Mapping
+
+- `apps/kanban_domain`: entities, value objects, domain policies, and port
+  behaviours that belong to the business core.
+- `apps/usecase`: application services and orchestration for business actions,
+  expressed as command and query handlers.
+- `apps/persistence`: adapters that satisfy repository or gateway ports.
+- `apps/web_api`: HTTP adapter that converts requests into commands or queries
+  and renders responses.
+
+## Design Checklist
+
+When reviewing or changing code, verify these points first:
+
+- Does the module name describe a business capability instead of a framework role?
+- Can the use case run without HTTP, database, or process runtime concerns?
+- Are dependencies crossing boundaries through behaviours, DTOs, or simple data?
+- Is the domain free from persistence state management and transport validation?
+- Is adapter code limited to translation, serialization, process wiring, or I/O?
+- Would a new developer infer the product use cases before noticing the framework?
+
+## Preferred Refactoring Direction
+
+When existing code is not aligned, move it in this order:
+
+1. Isolate business decisions into domain or use case modules.
+2. Introduce or tighten a port behaviour at the core boundary.
+3. Push HTTP, Agent, GenServer, or storage logic into an adapter.
+4. Replace generic module names with use-case-oriented names.
+5. Add regression tests around the use case and boundary contract.
+
+## Smells That Usually Need Refactoring
+
+- Domain modules calling `Agent`, `GenServer`, Plug, or persistence adapters directly.
+- Controllers or routers assembling business rules inline.
+- Use cases receiving raw framework params instead of a command or query DTO.
+- Commands and queries mixed in the same contract or described with CQRS language
+  when the implementation is still a single model with separate intent objects.
+- Repositories exposing storage-specific details into the domain.
+- Folder or module organization that highlights framework layers before use cases.
+- Tests that require the web server or real storage just to validate business rules.
+
+## Delivery Guidance
+
+- Keep explanations concrete: identify the violated boundary, then propose the
+  smallest change that restores the dependency direction.
+- Prefer incremental refactors over large rewrites.
+- Preserve structured logging and telemetry in application and adapter layers.
+- When architecture tradeoffs are unclear, choose the option that keeps the
+  domain more independent.
+
+## References
+
+If you need the rationale behind these rules, read
+`references/uncle_bob_clean_hexagonal.md`.

--- a/.codex/skills/clean-hexagonal-architecture/agents/openai.yaml
+++ b/.codex/skills/clean-hexagonal-architecture/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Clean Hexagonal Architecture"
+  short_description: "Refactoring guidance for clean architecture boundaries"
+  default_prompt: "Use $clean-hexagonal-architecture to review or refactor this code toward a clean, hexagonal architecture."

--- a/.codex/skills/clean-hexagonal-architecture/references/uncle_bob_clean_hexagonal.md
+++ b/.codex/skills/clean-hexagonal-architecture/references/uncle_bob_clean_hexagonal.md
@@ -1,0 +1,38 @@
+# Clean + Screaming Architecture Notes
+
+This reference condenses the architectural ideas requested for this repository.
+
+## Clean Architecture
+
+- The core business rules stay at the center and must not depend on frameworks,
+  databases, UI, or delivery mechanisms.
+- Source-code dependencies point inward. Outer layers can depend on inner
+  policies; inner layers must not know the outer mechanisms.
+- Boundaries are crossed through simple data structures or interfaces defined by
+  the core, so adapters can be replaced without changing business rules.
+- Use cases coordinate domain objects and represent application-specific actions.
+- Databases and web frameworks are tools. They should be replaceable details.
+
+## Screaming Architecture
+
+- The repository should "scream" the business domain and use cases, not the
+  framework or transport mechanism.
+- The top-level organization should help a reader infer what the system does.
+- Delivery mechanisms such as web, database, or jobs should remain secondary.
+- A healthy architecture keeps frameworks at arm's length so use cases stay
+  testable without infrastructure.
+
+## Mapping To This Repository
+
+- `kanban_domain` is the inner business core.
+- `usecase` is the application boundary where business actions are executed.
+- `persistence` and `web_api` are adapters on the outside.
+- GenServers coordinate work but should not absorb business policy.
+- Agent-backed repositories are infrastructure details behind repository ports.
+
+## Practical Review Questions
+
+- If the adapter changed, would the business rule code remain intact?
+- If the web layer disappeared, could the use case still run in a test?
+- If the storage mechanism changed, would the port contract remain stable?
+- Does the module naming highlight the business capability first?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,81 @@
+# Repository Guidelines
+
+This file is the primary Codex instruction source for this repository. Project-specific Codex guidance lives here and in `.codex/skills/`.
+
+## Architecture
+
+This is an Elixir umbrella project built around Screaming Architecture, Ports & Adapters, and DDD.
+
+- `apps/kanban_domain`: pure domain entities, value objects, and port behaviours.
+- `apps/persistence`: Agent-based repository adapters that implement domain ports.
+- `apps/usecase`: explicit use cases plus GenServer orchestrators and OTP supervision.
+- `apps/web_api`: Plug + Bandit HTTP adapter with OpenAPI docs.
+- `training/`: workshop material and repository documentation.
+
+Keep business logic in use cases and domain modules. Controllers, routers, jobs, and adapters only translate inputs and outputs.
+
+## Non-Negotiable Project Rules
+
+- Every business operation must have an explicit use case module.
+- Follow CQS, not CQRS for now: use cases receive either a command or a query DTO, never mixed ad-hoc parameters from adapters.
+- Domain code must not depend on HTTP, Plug, Agent, GenServer, or persistence details.
+- Repository mutations must use `Agent.get_and_update/3` for atomicity.
+- Agent access is pid-based; do not introduce atom registration.
+- GenServers orchestrate and delegate. They do not own business rules.
+- New business flows must include structured logging and telemetry.
+
+## Build, Test, and Verification
+
+Run commands from the repository root:
+
+```bash
+mix deps.get
+mix compile
+mix test
+mix test --only integration
+mix credo
+mix dialyzer
+MIX_ENV=test mix coveralls.github --umbrella
+mix format
+```
+
+CI runs `mix credo`, `mix dialyzer`, and `MIX_ENV=test mix coveralls.github --umbrella` in `.github/workflows/elixir.yml`.
+
+## Testing Expectations
+
+- Prefer fast unit tests with `use ExUnit.Case, async: true` when no shared state exists.
+- Add integration or contract tests for boundaries such as Agents, HTTP adapters, and port implementations.
+- For bug fixes, add a regression test that would have caught the issue.
+- Respect existing tags like `:integration` and domain-specific module tags.
+
+Coverage thresholds enforced per app:
+
+- `kanban_domain`: 70%
+- `persistence`: 100%
+- `usecase`: 50%
+- `web_api`: 80%
+
+## Conventions
+
+- Entities are created through `Module.new(...)` factories with UUIDs and audit timestamps.
+- Use descriptive business names; avoid generic `Service`, `Manager`, or CRUD-first modules when a use-case name is clearer.
+- Keep OpenAPI docs updated when HTTP contracts change.
+- Never log secrets or PII.
+
+## Project Skills
+
+Project-local Codex skills live under `.codex/skills/`. Each skill follows the official Codex shape:
+
+- `SKILL.md`: trigger metadata plus instructions
+- `agents/openai.yaml`: UI-facing metadata for Codex skill discovery
+
+Current project skills:
+
+- `adr`: guidance for creating and maintaining ADRs in the local repository convention.
+- `definition-of-done`: closure checklist before calling work complete.
+- `clean-hexagonal-architecture`: guidance for refactoring toward clean domain boundaries, explicit ports/adapters, and use-case-first structure.
+- `elixir`: Elixir/OTP and repository-specific coding guidance.
+- `flow`: reference for Flow-based data pipelines.
+- `gen-stage`: reference for GenStage and back-pressure pipelines.
+
+Use them as supporting references, not as a substitute for the architectural rules above.

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ This project recently underwent a major architectural refactoring to align with 
 - **Reliability** — validation catches errors early; contract tests prevent regressions
 - **Testability** — Use Cases are pure functions (except I/O), easy to unit test
 
-See [CLAUDE.md](CLAUDE.md) for the complete architectural standards and patterns followed.
+See [AGENTS.md](AGENTS.md) for the current Codex-oriented architectural standards, workflow rules, and project conventions.
 
 ## Contributing
 
@@ -413,7 +413,7 @@ Contributions are welcome! Please:
 3. Ensure all tests pass (`mix test`)
 4. Run the linter (`mix credo`)
 5. Check formatting (`mix format --check-formatted`)
-6. Read [CLAUDE.md](CLAUDE.md) and [GEMINI.md](GEMINI.md) for architectural patterns and the Definition of Done skill (`.claude/skills/definition-of-done/SKILL.md`) before completing features
+6. Read [AGENTS.md](AGENTS.md) and the project Codex skills under `.codex/skills/` before completing features
 7. Submit a pull request
 
 ## License

--- a/adr/0001-use-cqs-and-hexagonal-boundaries-with-in-memory-persistence.md
+++ b/adr/0001-use-cqs-and-hexagonal-boundaries-with-in-memory-persistence.md
@@ -1,0 +1,122 @@
+# 0001. Use CQS And Hexagonal Boundaries With In-Memory Persistence
+
+- Status: accepted
+- Date: 2026-03-27
+
+## Context
+
+The project is an Elixir umbrella organized around `kanban_domain`, `usecase`,
+`persistence`, and `web_api`.
+
+The intended architecture is closer to Clean Architecture, Hexagonal
+Architecture, and Screaming Architecture than to a framework-first design:
+
+- `kanban_domain` should remain clean and independent of transport, runtime
+  process details, and persistence mechanisms.
+- `usecase` should express business operations explicitly.
+- `persistence` should implement repository adapters.
+- `web_api` should translate HTTP requests and responses only.
+
+At the same time, the current project intentionally keeps state only during
+process execution to simplify the implementation. There is no immediate plan to
+implement CQRS. The near-term goal is to keep a simple in-memory runtime while
+preserving an architecture that can evolve toward object prevalence with
+persisted commands and snapshots later.
+
+Before this ADR, part of the application layer depended directly on concrete
+adapter modules such as `KanbanVisionApi.Agent.Organizations` and
+`KanbanVisionApi.Agent.Simulations`. Documentation also used CQRS terminology
+even though the implementation uses a single model and explicit command/query
+DTOs.
+
+## Decision
+
+We adopt the following architectural decisions for the project:
+
+1. The project follows CQS, not CQRS, at the application boundary.
+   Each use case entrypoint must receive either a Command DTO or a Query DTO.
+   Controllers, routers, and adapters must not pass mixed ad-hoc parameters into
+   use cases.
+
+2. In-memory persistence remains the current runtime model.
+   Agent-backed adapters are acceptable while the project keeps state alive only
+   during execution.
+
+3. The architecture must remain prevalence-ready.
+   Future persistence based on persisted commands and snapshots must be possible
+   without redesigning the domain and use case layers.
+
+4. Dependency direction must remain inward.
+   Domain and use case code must not depend directly on concrete persistence or
+   transport modules.
+
+5. Repository adapter selection must happen at the application boundary.
+   The composition root is responsible for wiring concrete adapters into the
+   application runtime.
+
+6. GenServer remains acceptable as an orchestration/runtime mechanism when it
+   represents the live application state, but it must not absorb business rules.
+
+## Consequences
+
+### Positive
+
+- The codebase stays aligned with a use-case-first architecture.
+- The project keeps its current implementation simplicity.
+- The path toward a prevalence-style persistence model remains open.
+- Business operations become easier to test independently of HTTP concerns.
+- Architectural terminology becomes more accurate and less misleading.
+
+### Negative
+
+- Some existing abstractions still expose runtime details such as `pid`.
+- The current adapters still carry infrastructure-oriented contracts that will
+  need another refactor phase.
+- The transition is incremental, so the codebase will temporarily contain a mix
+  of improved and still-pending architectural boundaries.
+
+## Execution Plan
+
+### Priority 1
+
+- Reinforce CQS in repository guidance and project documentation.
+- Centralize repository adapter selection in the application boundary.
+- Remove direct concrete adapter defaults from individual use case modules.
+
+Status:
+- Completed in this iteration.
+
+### Priority 2
+
+- Remove `pid` leakage from domain repository ports.
+- Replace infrastructure-shaped repository contracts with ports centered on
+  business intent.
+- Keep the in-memory implementation behind those refined ports.
+
+Status:
+- Planned.
+
+### Priority 3
+
+- Replace string-based error mapping between persistence, use case, and HTTP
+  with structured application errors.
+- Ensure HTTP status mapping depends on explicit error categories rather than
+  message parsing.
+
+Status:
+- Planned.
+
+### Priority 4
+
+- Make bounded contexts more uniform so `board`, `organization`, and
+  `simulation` follow the same architectural pattern.
+- Expand contract and integration coverage around ports and adapters.
+
+Status:
+- Planned.
+
+## Notes
+
+This ADR intentionally records target direction and phased execution together.
+The runtime remains in-memory for now, but future changes must preserve the
+decisions above unless a newer ADR supersedes this one.

--- a/adr/0002-remove-pid-leakage-from-domain-repository-ports.md
+++ b/adr/0002-remove-pid-leakage-from-domain-repository-ports.md
@@ -1,0 +1,159 @@
+# 0002. Remove PID Leakage From Domain Repository Ports
+
+- Status: planned
+- Date: 2026-03-27
+- Supersedes: none
+- Related: 0001-use-cqs-and-hexagonal-boundaries-with-in-memory-persistence
+
+## Context
+
+ADR 0001 established that the project should keep:
+
+- CQS at the application boundary
+- in-memory persistence during process execution
+- inward dependency direction
+- adapter selection at the application boundary
+- readiness for future evolution toward object prevalence
+
+After the first refactoring phase, the codebase still exposes `pid` in domain
+repository ports. This keeps a runtime process detail visible in the
+abstractions that should model business-facing persistence capabilities.
+
+Today, ports such as organization, simulation, and board repository contracts
+encode infrastructure-shaped signatures like:
+
+- `get_all(pid)`
+- `get_by_id(pid, id)`
+- `add(pid, entity)`
+- `delete(pid, id)`
+
+This has several consequences:
+
+- the core contract reflects the current Agent-based implementation
+- use cases and tests remain aware of process-oriented calling conventions
+- future prevalence-style persistence would have to preserve an incidental OTP
+  shape instead of implementing a cleaner business port
+
+The project still intends to keep live state in memory for now. Therefore, this
+ADR is not about removing runtime state or replacing Agents immediately. It is
+about planning a cleaner architectural boundary so the in-memory implementation
+becomes a detail behind the port.
+
+## Decision
+
+We plan to remove `pid` and other process-runtime details from domain repository
+ports and redefine those ports around business intent.
+
+The target direction is:
+
+1. Domain repository ports expose business-oriented operations only.
+   The port signature should describe the requested action and the business
+   inputs and outputs, not the runtime container used to fulfill it.
+
+2. Runtime handles stay outside the domain contract.
+   If an adapter needs process state, session state, or a runtime handle, that
+   concern must be owned by the application boundary or adapter composition, not
+   by the domain port definition.
+
+3. The in-memory adapter remains valid.
+   Agent-backed implementations can continue to exist, but they should satisfy a
+   cleaner port through internal encapsulation instead of exposing `pid` in the
+   contract itself.
+
+4. The refactor must preserve CQS.
+   Commands and queries remain explicit DTOs at the use case boundary, and the
+   repository contract must not reintroduce mixed ad-hoc parameter passing.
+
+## Considered Options
+
+### Option A
+
+Keep `pid` in the domain ports and accept process-oriented contracts as part of
+the architectural style.
+
+Why it was not chosen:
+
+- couples the core abstraction to the current Agent-based implementation
+- weakens the hexagonal boundary
+- makes the future prevalence migration less clean
+
+### Option B
+
+Remove `pid` from the ports and move runtime process concerns behind adapter
+composition.
+
+Why it is preferred:
+
+- keeps the core contract focused on persistence capability, not mechanism
+- aligns the codebase more closely with Clean and Hexagonal Architecture
+- preserves the ability to keep the current in-memory runtime
+
+## Consequences
+
+### Positive
+
+- Repository ports become cleaner and more stable.
+- The domain contract stops encoding an OTP implementation detail.
+- The path toward prevalence-style persistence becomes simpler.
+- Tests can be written against more meaningful contracts.
+
+### Negative
+
+- The refactor will touch multiple apps at once: `kanban_domain`, `usecase`,
+  and `persistence`.
+- Existing tests and helper setup will need coordinated adjustments.
+- The project may need an intermediate application-level abstraction to carry
+  runtime state cleanly.
+
+## Execution Plan
+
+### Phase 1: Port Redesign
+
+- Review all current repository behaviours in `kanban_domain`.
+- Define new signatures centered on business operations.
+- Remove `pid` from behaviour callbacks.
+
+Status:
+- Planned.
+
+### Phase 2: Application Boundary Adaptation
+
+- Identify where runtime state must live in `usecase`.
+- Introduce or refine the application-level composition needed to hold runtime
+  handles without pushing them into domain contracts.
+- Keep GenServer only as orchestration/runtime mechanism, not as a port shape.
+
+Status:
+- Planned.
+
+### Phase 3: Adapter Migration
+
+- Update Agent-backed adapters in `persistence` to satisfy the new ports.
+- Encapsulate internal process state so callers do not see `pid` in the
+  contract.
+- Preserve the current in-memory behavior.
+
+Status:
+- Planned.
+
+### Phase 4: Test And Documentation Alignment
+
+- Update contract tests and use case tests to the new boundary.
+- Align architectural documentation and examples with the new port shape.
+- Validate that ADR 0001 remains respected after the change.
+
+Status:
+- Planned.
+
+## Acceptance Criteria For Future Implementation
+
+- No domain repository behaviour exposes `pid` in its callback signatures.
+- Use case modules do not depend on Agent-shaped contracts.
+- In-memory persistence still works during process execution.
+- The resulting design remains compatible with a future prevalence-style
+  persistence model.
+
+## Notes
+
+This ADR records planning only. It does not authorize or imply implementation in
+the current session.

--- a/adr/README.md
+++ b/adr/README.md
@@ -1,0 +1,15 @@
+# Architectural Decision Records
+
+This directory stores the project's Architectural Decision Records (ADRs).
+
+## Convention
+
+- File names use the pattern `NNNN-short-kebab-case-title.md`.
+- ADRs follow a Nygard-style structure: `Status`, `Context`, `Decision`, and `Consequences`.
+- Prefer one decision per ADR.
+- When a decision unfolds incrementally, record the target direction and the execution phases in the same ADR.
+
+## Index
+
+- [0001-use-cqs-and-hexagonal-boundaries-with-in-memory-persistence](/Users/agnaldo4j/workspace/elixir/kanban_vision_api_iex/adr/0001-use-cqs-and-hexagonal-boundaries-with-in-memory-persistence.md)
+- [0002-remove-pid-leakage-from-domain-repository-ports](/Users/agnaldo4j/workspace/elixir/kanban_vision_api_iex/adr/0002-remove-pid-leakage-from-domain-repository-ports.md)

--- a/adr/README.md
+++ b/adr/README.md
@@ -11,5 +11,5 @@ This directory stores the project's Architectural Decision Records (ADRs).
 
 ## Index
 
-- [0001-use-cqs-and-hexagonal-boundaries-with-in-memory-persistence](/Users/agnaldo4j/workspace/elixir/kanban_vision_api_iex/adr/0001-use-cqs-and-hexagonal-boundaries-with-in-memory-persistence.md)
-- [0002-remove-pid-leakage-from-domain-repository-ports](/Users/agnaldo4j/workspace/elixir/kanban_vision_api_iex/adr/0002-remove-pid-leakage-from-domain-repository-ports.md)
+- [0001-use-cqs-and-hexagonal-boundaries-with-in-memory-persistence](0001-use-cqs-and-hexagonal-boundaries-with-in-memory-persistence.md)
+- [0002-remove-pid-leakage-from-domain-repository-ports](0002-remove-pid-leakage-from-domain-repository-ports.md)

--- a/apps/kanban_domain/README.md
+++ b/apps/kanban_domain/README.md
@@ -2,17 +2,11 @@
 
 ## Overview
 
-The `kanban_domain` is a core part of the Kanban Vision API. It's responsible for defining the domain logic and the state of the application. It's built with Elixir and leverages the power of functional programming and the actor model to provide a robust and scalable solution for simulating a Kanban system.
+The `kanban_domain` is the business core of the Kanban Vision API. It defines domain entities, value objects, and domain rules independently of HTTP, processes, or persistence mechanisms.
 
 ## Structure
 
-The `kanban_domain` is structured into two main parts: `Agents` and `Domain`.
-
-### Agents
-
-Agents in Elixir are a way to maintain state. In the context of the `kanban_domain`, agents are used to manage the state of different entities in the system such as `Boards`, `Organizations`, and `Simulations`.
-
-For example, the `Boards` agent is responsible for managing the state of a Kanban board. It maintains information about the board's workflow and can be interacted with to update the state of the board.
+The `kanban_domain` is structured around pure domain modules and port contracts.
 
 ### Domain
 

--- a/apps/persistence/README.md
+++ b/apps/persistence/README.md
@@ -2,25 +2,25 @@
 
 ## Overview
 
-The `persistence` application is a crucial component of the Kanban Vision API. It's responsible for managing the persistence layer of the application, ensuring that the state of the system is maintained across sessions. The application is built with Elixir and leverages the power of event sourcing and CQRS (Command Query Responsibility Segregation) to provide a robust and scalable solution for data persistence.
+The `persistence` application is responsible for the persistence boundary of the Kanban Vision API. Today it keeps application state in memory for the lifetime of the process to simplify the project runtime. The design should stay ready for future evolution toward persisted commands plus snapshots in a prevalence-style model without changing the core use cases.
 
-This application is inspired by the concepts of event logs and snapshots from the Akka actor model, and the prevalence system from the [Prevayler](http://prevayler.org/) project.
+This application is influenced by the prevalence system from the [Prevayler](http://prevayler.org/) project and by event log and snapshot ideas, but those mechanisms are not implemented yet in the current in-memory adapter.
 
 ## Structure
 
-The `persistence` application is structured around the concepts of event logs and snapshots.
+The `persistence` application is currently structured as in-memory adapters behind repository ports.
 
-### Event Logs
+### Current State
 
-Event logs are a record of all the events that have occurred in the system. Each event represents a change in the state of the system. By replaying these events, we can reconstruct the current state of the system. This approach is known as event sourcing.
+State lives only during process execution. Agent-backed adapters provide a simple persistence mechanism for development, tests, and architectural exploration.
 
-### Snapshots
+### Future Direction
 
-While event sourcing provides a robust way to maintain and reconstruct system state, replaying a long list of events can be time-consuming. To mitigate this, the `persistence` application uses snapshots. A snapshot is a saved state of a particular entity at a specific point in time. By saving snapshots periodically, we can reduce the number of events that need to be replayed to reconstruct the current state.
+The intended evolution is a prevalence-style persistence model with command persistence and snapshots. The application layer should continue to depend on ports so this change remains isolated to adapters.
 
-### CQRS
+### CQS
 
-CQRS stands for Command Query Responsibility Segregation. It's a pattern that separates reading data from writing data. In the context of the `persistence` application, we use CQRS to ensure that our event sourcing and snapshotting mechanisms can operate efficiently and independently of the query operations.
+At the application boundary, the project follows CQS: use cases accept either a Command or a Query DTO. This is distinct from CQRS and does not imply separate read and write models.
 
 ## Contributing
 
@@ -34,4 +34,4 @@ This project is licensed under the [MIT License](LICENSE).
 
 - [Prevayler](http://prevayler.org/)
 - [Akka Persistence](https://doc.akka.io/docs/akka/current/typed/persistence.html)
-- [CQRS](https://martinfowler.com/bliki/CQRS.html)
+- [CQS](https://martinfowler.com/bliki/CommandQuerySeparation.html)

--- a/apps/usecase/lib/kanban_vision_api/usecase/application.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/application.ex
@@ -5,11 +5,16 @@ defmodule KanbanVisionApi.Usecase.Application do
 
   use Application
 
+  alias KanbanVisionApi.Usecase.RepositoryConfig
+
   @impl true
   def start(_type, _args) do
     children = [
-      {KanbanVisionApi.Usecase.Organization, name: KanbanVisionApi.Usecase.Organization},
-      {KanbanVisionApi.Usecase.Simulation, name: KanbanVisionApi.Usecase.Simulation}
+      {KanbanVisionApi.Usecase.Organization,
+       name: KanbanVisionApi.Usecase.Organization,
+       repository: RepositoryConfig.fetch!(:organization)},
+      {KanbanVisionApi.Usecase.Simulation,
+       name: KanbanVisionApi.Usecase.Simulation, repository: RepositoryConfig.fetch!(:simulation)}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/apps/usecase/lib/kanban_vision_api/usecase/boards/delete_board.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/boards/delete_board.ex
@@ -12,14 +12,12 @@ defmodule KanbanVisionApi.Usecase.Boards.DeleteBoard do
   alias KanbanVisionApi.Usecase.Board.DeleteBoardCommand
   alias KanbanVisionApi.Usecase.EventEmitter
 
-  @default_repository KanbanVisionApi.Agent.Boards
-
   @type result :: {:ok, Board.t()} | {:error, String.t()}
 
   @spec execute(DeleteBoardCommand.t(), pid(), keyword()) :: result()
   def execute(%DeleteBoardCommand{} = cmd, repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
-    repository = Keyword.get(opts, :repository, @default_repository)
+    repository = Keyword.fetch!(opts, :repository)
 
     Logger.info("Deleting board",
       correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/boards/delete_board.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/boards/delete_board.ex
@@ -11,13 +11,14 @@ defmodule KanbanVisionApi.Usecase.Boards.DeleteBoard do
   alias KanbanVisionApi.Domain.Board
   alias KanbanVisionApi.Usecase.Board.DeleteBoardCommand
   alias KanbanVisionApi.Usecase.EventEmitter
+  alias KanbanVisionApi.Usecase.RepositoryConfig
 
   @type result :: {:ok, Board.t()} | {:error, String.t()}
 
   @spec execute(DeleteBoardCommand.t(), pid(), keyword()) :: result()
   def execute(%DeleteBoardCommand{} = cmd, repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
-    repository = Keyword.fetch!(opts, :repository)
+    repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
 
     Logger.info("Deleting board",
       correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/organization.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organization.ex
@@ -17,12 +17,12 @@ defmodule KanbanVisionApi.Usecase.Organization do
   alias KanbanVisionApi.Usecase.Organizations.GetAllOrganizations
   alias KanbanVisionApi.Usecase.Organizations.GetOrganizationById
   alias KanbanVisionApi.Usecase.Organizations.GetOrganizationByName
-
-  @default_repository KanbanVisionApi.Agent.Organizations
+  alias KanbanVisionApi.Usecase.RepositoryConfig
 
   # Client API
 
   def start_link(opts \\ []) do
+    opts = Keyword.put_new(opts, :repository, RepositoryConfig.fetch!(:organization))
     GenServer.start_link(__MODULE__, opts, Keyword.take(opts, [:name]))
   end
 
@@ -48,7 +48,7 @@ defmodule KanbanVisionApi.Usecase.Organization do
 
   @impl true
   def init(opts) do
-    repository = Keyword.get(opts, :repository, @default_repository)
+    repository = Keyword.fetch!(opts, :repository)
     {:ok, agent_pid} = repository.start_link()
     {:ok, %{repository_pid: agent_pid, repository: repository}}
   end

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/create_organization.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/create_organization.ex
@@ -12,14 +12,12 @@ defmodule KanbanVisionApi.Usecase.Organizations.CreateOrganization do
   alias KanbanVisionApi.Usecase.EventEmitter
   alias KanbanVisionApi.Usecase.Organization.CreateOrganizationCommand
 
-  @default_repository KanbanVisionApi.Agent.Organizations
-
   @type result :: {:ok, Organization.t()} | {:error, String.t()}
 
   @spec execute(CreateOrganizationCommand.t(), pid(), keyword()) :: result()
   def execute(%CreateOrganizationCommand{} = cmd, repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
-    repository = Keyword.get(opts, :repository, @default_repository)
+    repository = Keyword.fetch!(opts, :repository)
 
     Logger.info("Creating organization",
       correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/create_organization.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/create_organization.ex
@@ -11,13 +11,14 @@ defmodule KanbanVisionApi.Usecase.Organizations.CreateOrganization do
   alias KanbanVisionApi.Domain.Organization
   alias KanbanVisionApi.Usecase.EventEmitter
   alias KanbanVisionApi.Usecase.Organization.CreateOrganizationCommand
+  alias KanbanVisionApi.Usecase.RepositoryConfig
 
   @type result :: {:ok, Organization.t()} | {:error, String.t()}
 
   @spec execute(CreateOrganizationCommand.t(), pid(), keyword()) :: result()
   def execute(%CreateOrganizationCommand{} = cmd, repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
-    repository = Keyword.fetch!(opts, :repository)
+    repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
 
     Logger.info("Creating organization",
       correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/delete_organization.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/delete_organization.ex
@@ -11,13 +11,14 @@ defmodule KanbanVisionApi.Usecase.Organizations.DeleteOrganization do
   alias KanbanVisionApi.Domain.Organization
   alias KanbanVisionApi.Usecase.EventEmitter
   alias KanbanVisionApi.Usecase.Organization.DeleteOrganizationCommand
+  alias KanbanVisionApi.Usecase.RepositoryConfig
 
   @type result :: {:ok, Organization.t()} | {:error, String.t()}
 
   @spec execute(DeleteOrganizationCommand.t(), pid(), keyword()) :: result()
   def execute(%DeleteOrganizationCommand{} = cmd, repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
-    repository = Keyword.fetch!(opts, :repository)
+    repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
 
     Logger.info("Deleting organization",
       correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/delete_organization.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/delete_organization.ex
@@ -12,14 +12,12 @@ defmodule KanbanVisionApi.Usecase.Organizations.DeleteOrganization do
   alias KanbanVisionApi.Usecase.EventEmitter
   alias KanbanVisionApi.Usecase.Organization.DeleteOrganizationCommand
 
-  @default_repository KanbanVisionApi.Agent.Organizations
-
   @type result :: {:ok, Organization.t()} | {:error, String.t()}
 
   @spec execute(DeleteOrganizationCommand.t(), pid(), keyword()) :: result()
   def execute(%DeleteOrganizationCommand{} = cmd, repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
-    repository = Keyword.get(opts, :repository, @default_repository)
+    repository = Keyword.fetch!(opts, :repository)
 
     Logger.info("Deleting organization",
       correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_all_organizations.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_all_organizations.ex
@@ -8,13 +8,14 @@ defmodule KanbanVisionApi.Usecase.Organizations.GetAllOrganizations do
   require Logger
 
   alias KanbanVisionApi.Usecase.EventEmitter
+  alias KanbanVisionApi.Usecase.RepositoryConfig
 
   @type result :: {:ok, map()}
 
   @spec execute(pid(), keyword()) :: result()
   def execute(repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
-    repository = Keyword.fetch!(opts, :repository)
+    repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
 
     Logger.debug("Retrieving all organizations", correlation_id: correlation_id)
 

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_all_organizations.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_all_organizations.ex
@@ -9,14 +9,12 @@ defmodule KanbanVisionApi.Usecase.Organizations.GetAllOrganizations do
 
   alias KanbanVisionApi.Usecase.EventEmitter
 
-  @default_repository KanbanVisionApi.Agent.Organizations
-
   @type result :: {:ok, map()}
 
   @spec execute(pid(), keyword()) :: result()
   def execute(repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
-    repository = Keyword.get(opts, :repository, @default_repository)
+    repository = Keyword.fetch!(opts, :repository)
 
     Logger.debug("Retrieving all organizations", correlation_id: correlation_id)
 

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_id.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_id.ex
@@ -10,14 +10,12 @@ defmodule KanbanVisionApi.Usecase.Organizations.GetOrganizationById do
   alias KanbanVisionApi.Domain.Organization
   alias KanbanVisionApi.Usecase.Organization.GetOrganizationByIdQuery
 
-  @default_repository KanbanVisionApi.Agent.Organizations
-
   @type result :: {:ok, Organization.t()} | {:error, String.t()}
 
   @spec execute(GetOrganizationByIdQuery.t(), pid(), keyword()) :: result()
   def execute(%GetOrganizationByIdQuery{} = query, repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
-    repository = Keyword.get(opts, :repository, @default_repository)
+    repository = Keyword.fetch!(opts, :repository)
 
     Logger.debug("Retrieving organization by ID",
       correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_id.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_id.ex
@@ -9,13 +9,14 @@ defmodule KanbanVisionApi.Usecase.Organizations.GetOrganizationById do
 
   alias KanbanVisionApi.Domain.Organization
   alias KanbanVisionApi.Usecase.Organization.GetOrganizationByIdQuery
+  alias KanbanVisionApi.Usecase.RepositoryConfig
 
   @type result :: {:ok, Organization.t()} | {:error, String.t()}
 
   @spec execute(GetOrganizationByIdQuery.t(), pid(), keyword()) :: result()
   def execute(%GetOrganizationByIdQuery{} = query, repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
-    repository = Keyword.fetch!(opts, :repository)
+    repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
 
     Logger.debug("Retrieving organization by ID",
       correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_name.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_name.ex
@@ -8,13 +8,14 @@ defmodule KanbanVisionApi.Usecase.Organizations.GetOrganizationByName do
   require Logger
 
   alias KanbanVisionApi.Usecase.Organization.GetOrganizationByNameQuery
+  alias KanbanVisionApi.Usecase.RepositoryConfig
 
   @type result :: {:ok, list()} | {:error, String.t()}
 
   @spec execute(GetOrganizationByNameQuery.t(), pid(), keyword()) :: result()
   def execute(%GetOrganizationByNameQuery{} = query, repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
-    repository = Keyword.fetch!(opts, :repository)
+    repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
 
     Logger.debug("Retrieving organizations by name",
       correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_name.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_name.ex
@@ -9,14 +9,12 @@ defmodule KanbanVisionApi.Usecase.Organizations.GetOrganizationByName do
 
   alias KanbanVisionApi.Usecase.Organization.GetOrganizationByNameQuery
 
-  @default_repository KanbanVisionApi.Agent.Organizations
-
   @type result :: {:ok, list()} | {:error, String.t()}
 
   @spec execute(GetOrganizationByNameQuery.t(), pid(), keyword()) :: result()
   def execute(%GetOrganizationByNameQuery{} = query, repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
-    repository = Keyword.get(opts, :repository, @default_repository)
+    repository = Keyword.fetch!(opts, :repository)
 
     Logger.debug("Retrieving organizations by name",
       correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/repository_config.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/repository_config.ex
@@ -16,4 +16,17 @@ defmodule KanbanVisionApi.Usecase.RepositoryConfig do
 
     Keyword.fetch!(repositories, key)
   end
+
+  @spec fetch_from_opts!(module(), keyword()) :: module()
+  def fetch_from_opts!(caller, opts) when is_list(opts) do
+    case Keyword.fetch(opts, :repository) do
+      {:ok, repository} ->
+        repository
+
+      :error ->
+        raise ArgumentError,
+              "missing required :repository option when calling " <>
+                "#{inspect(caller)}.execute/3. Ensure repository wiring is configured."
+    end
+  end
 end

--- a/apps/usecase/lib/kanban_vision_api/usecase/repository_config.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/repository_config.ex
@@ -1,0 +1,19 @@
+defmodule KanbanVisionApi.Usecase.RepositoryConfig do
+  @moduledoc """
+  Centralizes repository adapter selection for the application layer.
+
+  Use cases depend on repository ports and receive the concrete adapter through
+  runtime composition, keeping Command/Query execution decoupled from specific
+  persistence modules.
+  """
+
+  @type repository_key :: :organization | :simulation
+
+  @spec fetch!(repository_key()) :: module()
+  def fetch!(key) when key in [:organization, :simulation] do
+    repositories =
+      Application.get_env(:usecase, :repositories, [])
+
+    Keyword.fetch!(repositories, key)
+  end
+end

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulation.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulation.ex
@@ -15,12 +15,12 @@ defmodule KanbanVisionApi.Usecase.Simulation do
   alias KanbanVisionApi.Usecase.Simulations.DeleteSimulation
   alias KanbanVisionApi.Usecase.Simulations.GetAllSimulations
   alias KanbanVisionApi.Usecase.Simulations.GetSimulationByOrgAndName
-
-  @default_repository KanbanVisionApi.Agent.Simulations
+  alias KanbanVisionApi.Usecase.RepositoryConfig
 
   # Client API
 
   def start_link(opts \\ []) do
+    opts = Keyword.put_new(opts, :repository, RepositoryConfig.fetch!(:simulation))
     GenServer.start_link(__MODULE__, opts, Keyword.take(opts, [:name]))
   end
 
@@ -42,7 +42,7 @@ defmodule KanbanVisionApi.Usecase.Simulation do
 
   @impl true
   def init(opts) do
-    repository = Keyword.get(opts, :repository, @default_repository)
+    repository = Keyword.fetch!(opts, :repository)
     {:ok, agent_pid} = repository.start_link()
     {:ok, %{repository_pid: agent_pid, repository: repository}}
   end

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulations/create_simulation.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulations/create_simulation.ex
@@ -10,6 +10,7 @@ defmodule KanbanVisionApi.Usecase.Simulations.CreateSimulation do
 
   alias KanbanVisionApi.Domain.Simulation
   alias KanbanVisionApi.Usecase.EventEmitter
+  alias KanbanVisionApi.Usecase.RepositoryConfig
   alias KanbanVisionApi.Usecase.Simulation.CreateSimulationCommand
 
   @type result :: {:ok, Simulation.t()} | {:error, String.t()}
@@ -17,7 +18,7 @@ defmodule KanbanVisionApi.Usecase.Simulations.CreateSimulation do
   @spec execute(CreateSimulationCommand.t(), pid(), keyword()) :: result()
   def execute(%CreateSimulationCommand{} = cmd, repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
-    repository = Keyword.fetch!(opts, :repository)
+    repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
 
     Logger.info("Creating simulation",
       correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulations/create_simulation.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulations/create_simulation.ex
@@ -12,14 +12,12 @@ defmodule KanbanVisionApi.Usecase.Simulations.CreateSimulation do
   alias KanbanVisionApi.Usecase.EventEmitter
   alias KanbanVisionApi.Usecase.Simulation.CreateSimulationCommand
 
-  @default_repository KanbanVisionApi.Agent.Simulations
-
   @type result :: {:ok, Simulation.t()} | {:error, String.t()}
 
   @spec execute(CreateSimulationCommand.t(), pid(), keyword()) :: result()
   def execute(%CreateSimulationCommand{} = cmd, repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
-    repository = Keyword.get(opts, :repository, @default_repository)
+    repository = Keyword.fetch!(opts, :repository)
 
     Logger.info("Creating simulation",
       correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulations/delete_simulation.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulations/delete_simulation.ex
@@ -12,14 +12,12 @@ defmodule KanbanVisionApi.Usecase.Simulations.DeleteSimulation do
   alias KanbanVisionApi.Usecase.EventEmitter
   alias KanbanVisionApi.Usecase.Simulation.DeleteSimulationCommand
 
-  @default_repository KanbanVisionApi.Agent.Simulations
-
   @type result :: {:ok, Simulation.t()} | {:error, String.t()}
 
   @spec execute(DeleteSimulationCommand.t(), pid(), keyword()) :: result()
   def execute(%DeleteSimulationCommand{} = cmd, repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
-    repository = Keyword.get(opts, :repository, @default_repository)
+    repository = Keyword.fetch!(opts, :repository)
 
     Logger.info("Deleting simulation",
       correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulations/delete_simulation.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulations/delete_simulation.ex
@@ -10,6 +10,7 @@ defmodule KanbanVisionApi.Usecase.Simulations.DeleteSimulation do
 
   alias KanbanVisionApi.Domain.Simulation
   alias KanbanVisionApi.Usecase.EventEmitter
+  alias KanbanVisionApi.Usecase.RepositoryConfig
   alias KanbanVisionApi.Usecase.Simulation.DeleteSimulationCommand
 
   @type result :: {:ok, Simulation.t()} | {:error, String.t()}
@@ -17,7 +18,7 @@ defmodule KanbanVisionApi.Usecase.Simulations.DeleteSimulation do
   @spec execute(DeleteSimulationCommand.t(), pid(), keyword()) :: result()
   def execute(%DeleteSimulationCommand{} = cmd, repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
-    repository = Keyword.fetch!(opts, :repository)
+    repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
 
     Logger.info("Deleting simulation",
       correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulations/get_all_simulations.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulations/get_all_simulations.ex
@@ -8,13 +8,14 @@ defmodule KanbanVisionApi.Usecase.Simulations.GetAllSimulations do
   require Logger
 
   alias KanbanVisionApi.Usecase.EventEmitter
+  alias KanbanVisionApi.Usecase.RepositoryConfig
 
   @type result :: {:ok, map()}
 
   @spec execute(pid(), keyword()) :: result()
   def execute(repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
-    repository = Keyword.fetch!(opts, :repository)
+    repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
 
     Logger.debug("Retrieving all simulations", correlation_id: correlation_id)
 

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulations/get_all_simulations.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulations/get_all_simulations.ex
@@ -9,14 +9,12 @@ defmodule KanbanVisionApi.Usecase.Simulations.GetAllSimulations do
 
   alias KanbanVisionApi.Usecase.EventEmitter
 
-  @default_repository KanbanVisionApi.Agent.Simulations
-
   @type result :: {:ok, map()}
 
   @spec execute(pid(), keyword()) :: result()
   def execute(repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
-    repository = Keyword.get(opts, :repository, @default_repository)
+    repository = Keyword.fetch!(opts, :repository)
 
     Logger.debug("Retrieving all simulations", correlation_id: correlation_id)
 

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulations/get_simulation_by_org_and_name.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulations/get_simulation_by_org_and_name.ex
@@ -7,6 +7,7 @@ defmodule KanbanVisionApi.Usecase.Simulations.GetSimulationByOrgAndName do
 
   require Logger
 
+  alias KanbanVisionApi.Usecase.RepositoryConfig
   alias KanbanVisionApi.Usecase.Simulation.GetSimulationByOrgAndNameQuery
 
   @type result ::
@@ -15,7 +16,7 @@ defmodule KanbanVisionApi.Usecase.Simulations.GetSimulationByOrgAndName do
   @spec execute(GetSimulationByOrgAndNameQuery.t(), pid(), keyword()) :: result()
   def execute(%GetSimulationByOrgAndNameQuery{} = query, repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
-    repository = Keyword.fetch!(opts, :repository)
+    repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
 
     Logger.debug("Retrieving simulation by org and name",
       correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulations/get_simulation_by_org_and_name.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulations/get_simulation_by_org_and_name.ex
@@ -9,15 +9,13 @@ defmodule KanbanVisionApi.Usecase.Simulations.GetSimulationByOrgAndName do
 
   alias KanbanVisionApi.Usecase.Simulation.GetSimulationByOrgAndNameQuery
 
-  @default_repository KanbanVisionApi.Agent.Simulations
-
   @type result ::
           {:ok, KanbanVisionApi.Domain.Simulation.t()} | {:error, String.t()}
 
   @spec execute(GetSimulationByOrgAndNameQuery.t(), pid(), keyword()) :: result()
   def execute(%GetSimulationByOrgAndNameQuery{} = query, repository_pid, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
-    repository = Keyword.get(opts, :repository, @default_repository)
+    repository = Keyword.fetch!(opts, :repository)
 
     Logger.debug("Retrieving simulation by org and name",
       correlation_id: correlation_id,

--- a/apps/web_api/lib/kanban_vision_api/web_api/adapters/organization_adapter.ex
+++ b/apps/web_api/lib/kanban_vision_api/web_api/adapters/organization_adapter.ex
@@ -1,8 +1,8 @@
 defmodule KanbanVisionApi.WebApi.Adapters.OrganizationAdapter do
   @moduledoc """
-  Adapter: bridges the OrganizationUsecase port to the Organization GenServer.
+  Adapter: bridges the OrganizationUsecase port to the organization application boundary.
 
-  Calls the registered GenServer using the module name as the server reference.
+  Calls the configured runtime entrypoint without leaking transport details into HTTP code.
   """
 
   @behaviour KanbanVisionApi.WebApi.Ports.OrganizationUsecase

--- a/apps/web_api/lib/kanban_vision_api/web_api/adapters/simulation_adapter.ex
+++ b/apps/web_api/lib/kanban_vision_api/web_api/adapters/simulation_adapter.ex
@@ -1,8 +1,8 @@
 defmodule KanbanVisionApi.WebApi.Adapters.SimulationAdapter do
   @moduledoc """
-  Adapter: bridges the SimulationUsecase port to the Simulation GenServer.
+  Adapter: bridges the SimulationUsecase port to the simulation application boundary.
 
-  Calls the registered GenServer using the module name as the server reference.
+  Calls the configured runtime entrypoint without leaking transport details into HTTP code.
   """
 
   @behaviour KanbanVisionApi.WebApi.Ports.SimulationUsecase

--- a/apps/web_api/lib/kanban_vision_api/web_api/ports/organization_usecase.ex
+++ b/apps/web_api/lib/kanban_vision_api/web_api/ports/organization_usecase.ex
@@ -2,7 +2,7 @@ defmodule KanbanVisionApi.WebApi.Ports.OrganizationUsecase do
   @moduledoc """
   Port: defines the Organization use case interface for the web layer.
 
-  Decouples HTTP adapters from the concrete GenServer implementation,
+  Decouples HTTP adapters from the concrete application boundary,
   enabling Mox-based unit testing of controllers.
   """
 

--- a/apps/web_api/lib/kanban_vision_api/web_api/ports/simulation_usecase.ex
+++ b/apps/web_api/lib/kanban_vision_api/web_api/ports/simulation_usecase.ex
@@ -2,7 +2,7 @@ defmodule KanbanVisionApi.WebApi.Ports.SimulationUsecase do
   @moduledoc """
   Port: defines the Simulation use case interface for the web layer.
 
-  Decouples HTTP adapters from the concrete GenServer implementation,
+  Decouples HTTP adapters from the concrete application boundary,
   enabling Mox-based unit testing of controllers.
   """
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -31,6 +31,12 @@ config :logger, :console,
 
 config :web_api, port: 4000
 
+config :usecase,
+  repositories: [
+    organization: KanbanVisionApi.Agent.Organizations,
+    simulation: KanbanVisionApi.Agent.Simulations
+  ]
+
 if config_env() == :test do
   import_config "test.exs"
 end


### PR DESCRIPTION
## Summary
- add project ADR infrastructure plus ADR-0001 and ADR-0002 for the architecture roadmap
- add Codex skills for clean hexagonal architecture and ADR authoring, and register them in project guidance
- centralize repository adapter wiring in the usecase boundary and update architecture docs to reinforce CQS and the current in-memory persistence model

## Validation
- mix format
- mix test apps/usecase/test/kanban_vision_api/usecase/organization_test.exs apps/usecase/test/kanban_vision_api/usecase/simulation_test.exs apps/web_api/test/kanban_vision_api/web_api/adapters/organization_adapter_test.exs apps/web_api/test/kanban_vision_api/web_api/adapters/simulation_adapter_test.exs apps/web_api/test/kanban_vision_api/web_api/organizations/organization_controller_test.exs apps/web_api/test/kanban_vision_api/web_api/simulations/simulation_controller_test.exs apps/web_api/test/kanban_vision_api/web_api/router_test.exs

## Notes
- the working tree still has unrelated local changes outside this PR and they were intentionally left out of the commit