### PR TITLE
refactor: hide agent pid behind repository runtime

### DIFF
--- a/.codex/skills/elixir/SKILL.md
+++ b/.codex/skills/elixir/SKILL.md
@@ -27,7 +27,7 @@ mix format
 ## Repository-Specific Rules
 
 - `apps/kanban_domain` stays pure: no HTTP, Agent, or GenServer dependencies.
-- `apps/persistence` implements domain ports with Agents and pid-based access.
+- `apps/persistence` implements domain ports with Agents while keeping raw `pid` access internal to the adapter runtime.
 - `apps/usecase` contains one use case per operation; GenServers orchestrate only.
 - `apps/web_api` adapts HTTP requests to commands and queries through Plug + Bandit.
 - Commands and queries should validate at construction time through factory functions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Keep business logic in use cases and domain modules. Controllers, routers, jobs,
 - Follow CQS, not CQRS for now: use cases receive either a command or a query DTO, never mixed ad-hoc parameters from adapters.
 - Domain code must not depend on HTTP, Plug, Agent, GenServer, or persistence details.
 - Repository mutations must use `Agent.get_and_update/3` for atomicity.
-- Agent access is pid-based; do not introduce atom registration.
+- Agent access stays internal to persistence adapters; do not expose raw `pid` in domain ports or introduce atom registration.
 - GenServers orchestrate and delegate. They do not own business rules.
 - New business flows must include structured logging and telemetry.
 

--- a/README.md
+++ b/README.md
@@ -106,11 +106,11 @@ Each business operation has a dedicated Use Case module with **logging**, **tele
 ```elixir
 # Use Case structure
 defmodule Organizations.CreateOrganization do
-  def execute(cmd, repository_pid, opts \\ []) do
+  def execute(cmd, repository_runtime, opts \\ []) do
     Logger.info("Creating organization", ...)  # 📊 Observability
     organization = Organization.new(cmd.name)
 
-    case OrganizationRepository.add(repository_pid, organization) do
+    case OrganizationRepository.add(repository_runtime, organization) do
       {:ok, org} ->
         emit_telemetry_event(...)               # 📈 Metrics
         {:ok, org}
@@ -221,7 +221,7 @@ apps/
 - ✅ **Early Failure** — invalid input rejected before domain logic executes
 
 ### **4. Repository Pattern (Ports & Adapters)**
-- 🔌 **Agents use pid-based access** (no atom name registration) to avoid atom table exhaustion
+- 🔌 **Agents stay internal to persistence adapters** through opaque runtimes (still no atom name registration)
 - 🔌 **Agent mutations use `Agent.get_and_update`** (not separate get + update) to prevent race conditions
 - 🔌 **Agents implement @behaviour Ports** — easy to swap implementations (e.g., Postgres adapter)
 

--- a/adr/0002-remove-pid-leakage-from-domain-repository-ports.md
+++ b/adr/0002-remove-pid-leakage-from-domain-repository-ports.md
@@ -1,6 +1,6 @@
 # 0002. Remove PID Leakage From Domain Repository Ports
 
-- Status: planned
+- Status: accepted
 - Date: 2026-03-27
 - Supersedes: none
 - Related: 0001-use-cqs-and-hexagonal-boundaries-with-in-memory-persistence
@@ -114,7 +114,7 @@ Why it is preferred:
 - Remove `pid` from behaviour callbacks.
 
 Status:
-- Planned.
+- Completed on 2026-03-27.
 
 ### Phase 2: Application Boundary Adaptation
 
@@ -124,7 +124,7 @@ Status:
 - Keep GenServer only as orchestration/runtime mechanism, not as a port shape.
 
 Status:
-- Planned.
+- Completed on 2026-03-27.
 
 ### Phase 3: Adapter Migration
 
@@ -134,7 +134,7 @@ Status:
 - Preserve the current in-memory behavior.
 
 Status:
-- Planned.
+- Completed on 2026-03-27.
 
 ### Phase 4: Test And Documentation Alignment
 
@@ -143,7 +143,7 @@ Status:
 - Validate that ADR 0001 remains respected after the change.
 
 Status:
-- Planned.
+- Completed on 2026-03-27.
 
 ## Acceptance Criteria For Future Implementation
 
@@ -155,5 +155,9 @@ Status:
 
 ## Notes
 
-This ADR records planning only. It does not authorize or imply implementation in
-the current session.
+Implementation completed on 2026-03-27 with these boundaries:
+
+- domain ports now accept opaque repository runtimes instead of `pid`
+- `usecase` orchestrators store `repository_runtime` and delegate through ports
+- Agent adapters encapsulate the raw `pid` in runtime structs
+- contract and adapter tests were updated to the new boundary

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/ports/board_repository.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/ports/board_repository.ex
@@ -4,8 +4,9 @@ defmodule KanbanVisionApi.Domain.Ports.BoardRepository do
   """
 
   alias KanbanVisionApi.Domain.Board
+  alias KanbanVisionApi.Domain.Ports.RepositoryRuntime
 
-  @type repository_runtime :: term()
+  @type repository_runtime :: RepositoryRuntime.t()
 
   @callback get_all(runtime :: repository_runtime()) :: map()
   @callback get_by_id(runtime :: repository_runtime(), id :: String.t()) ::

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/ports/board_repository.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/ports/board_repository.ex
@@ -5,12 +5,15 @@ defmodule KanbanVisionApi.Domain.Ports.BoardRepository do
 
   alias KanbanVisionApi.Domain.Board
 
-  @callback get_all(pid :: pid()) :: map()
-  @callback get_by_id(pid :: pid(), id :: String.t()) ::
+  @type repository_runtime :: term()
+
+  @callback get_all(runtime :: repository_runtime()) :: map()
+  @callback get_by_id(runtime :: repository_runtime(), id :: String.t()) ::
               {:ok, Board.t()} | {:error, String.t()}
-  @callback add(pid :: pid(), board :: Board.t()) :: {:ok, Board.t()} | {:error, String.t()}
-  @callback delete(pid :: pid(), id :: String.t()) ::
+  @callback add(runtime :: repository_runtime(), board :: Board.t()) ::
               {:ok, Board.t()} | {:error, String.t()}
-  @callback get_all_by_simulation_id(pid :: pid(), simulation_id :: String.t()) ::
+  @callback delete(runtime :: repository_runtime(), id :: String.t()) ::
+              {:ok, Board.t()} | {:error, String.t()}
+  @callback get_all_by_simulation_id(runtime :: repository_runtime(), simulation_id :: String.t()) ::
               {:ok, [Board.t()]} | {:error, String.t()}
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/ports/organization_repository.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/ports/organization_repository.ex
@@ -4,8 +4,9 @@ defmodule KanbanVisionApi.Domain.Ports.OrganizationRepository do
   """
 
   alias KanbanVisionApi.Domain.Organization
+  alias KanbanVisionApi.Domain.Ports.RepositoryRuntime
 
-  @type repository_runtime :: term()
+  @type repository_runtime :: RepositoryRuntime.t()
 
   @callback get_all(runtime :: repository_runtime()) :: map()
   @callback get_by_id(runtime :: repository_runtime(), id :: String.t()) ::

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/ports/organization_repository.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/ports/organization_repository.ex
@@ -5,13 +5,15 @@ defmodule KanbanVisionApi.Domain.Ports.OrganizationRepository do
 
   alias KanbanVisionApi.Domain.Organization
 
-  @callback get_all(pid :: pid()) :: map()
-  @callback get_by_id(pid :: pid(), id :: String.t()) ::
+  @type repository_runtime :: term()
+
+  @callback get_all(runtime :: repository_runtime()) :: map()
+  @callback get_by_id(runtime :: repository_runtime(), id :: String.t()) ::
               {:ok, Organization.t()} | {:error, String.t()}
-  @callback get_by_name(pid :: pid(), name :: String.t()) ::
+  @callback get_by_name(runtime :: repository_runtime(), name :: String.t()) ::
               {:ok, [Organization.t()]} | {:error, String.t()}
-  @callback add(pid :: pid(), organization :: Organization.t()) ::
+  @callback add(runtime :: repository_runtime(), organization :: Organization.t()) ::
               {:ok, Organization.t()} | {:error, String.t()}
-  @callback delete(pid :: pid(), id :: String.t()) ::
+  @callback delete(runtime :: repository_runtime(), id :: String.t()) ::
               {:ok, Organization.t()} | {:error, String.t()}
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/ports/repository_runtime.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/ports/repository_runtime.ex
@@ -1,0 +1,7 @@
+defmodule KanbanVisionApi.Domain.Ports.RepositoryRuntime do
+  @moduledoc """
+  Opaque runtime handle used by persistence adapters outside the pure domain.
+  """
+
+  @type t :: term()
+end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/ports/simulation_repository.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/ports/simulation_repository.ex
@@ -3,9 +3,10 @@ defmodule KanbanVisionApi.Domain.Ports.SimulationRepository do
   Port defining the contract for simulation persistence.
   """
 
+  alias KanbanVisionApi.Domain.Ports.RepositoryRuntime
   alias KanbanVisionApi.Domain.Simulation
 
-  @type repository_runtime :: term()
+  @type repository_runtime :: RepositoryRuntime.t()
 
   @callback get_all(runtime :: repository_runtime()) :: map()
   @callback add(runtime :: repository_runtime(), simulation :: Simulation.t()) ::

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/ports/simulation_repository.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/ports/simulation_repository.ex
@@ -5,13 +5,15 @@ defmodule KanbanVisionApi.Domain.Ports.SimulationRepository do
 
   alias KanbanVisionApi.Domain.Simulation
 
-  @callback get_all(pid :: pid()) :: map()
-  @callback add(pid :: pid(), simulation :: Simulation.t()) ::
+  @type repository_runtime :: term()
+
+  @callback get_all(runtime :: repository_runtime()) :: map()
+  @callback add(runtime :: repository_runtime(), simulation :: Simulation.t()) ::
               {:ok, Simulation.t()} | {:error, String.t()}
-  @callback delete(pid :: pid(), id :: String.t()) ::
+  @callback delete(runtime :: repository_runtime(), id :: String.t()) ::
               {:ok, Simulation.t()} | {:error, String.t()}
   @callback get_by_organization_id_and_simulation_name(
-              pid :: pid(),
+              runtime :: repository_runtime(),
               org_id :: String.t(),
               name :: String.t()
             ) :: {:ok, Simulation.t()} | {:error, String.t()}

--- a/apps/persistence/lib/kanban_vision_api/agent/boards.ex
+++ b/apps/persistence/lib/kanban_vision_api/agent/boards.ex
@@ -5,12 +5,21 @@ defmodule KanbanVisionApi.Agent.Boards do
 
   @behaviour KanbanVisionApi.Domain.Ports.BoardRepository
 
+  defmodule Runtime do
+    @moduledoc false
+
+    @enforce_keys [:pid]
+    defstruct [:pid]
+  end
+
   defstruct [:id, :boards]
 
   @type t :: %__MODULE__{
           id: String.t(),
           boards: map()
         }
+
+  @opaque runtime :: %Runtime{pid: pid()}
 
   def new(boards \\ %{}, id \\ UUID.uuid4()) do
     %__MODULE__{
@@ -21,12 +30,15 @@ defmodule KanbanVisionApi.Agent.Boards do
 
   # Client
 
-  @spec start_link(t()) :: Agent.on_start()
+  @spec start_link(t()) :: {:ok, runtime()} | {:error, term()}
   def start_link(default \\ __MODULE__.new()) do
-    Agent.start_link(fn -> default end)
+    case Agent.start_link(fn -> default end) do
+      {:ok, pid} -> {:ok, %Runtime{pid: pid}}
+      {:error, reason} -> {:error, reason}
+    end
   end
 
-  def add(pid, %KanbanVisionApi.Domain.Board{} = new_board) do
+  def add(%Runtime{pid: pid}, %KanbanVisionApi.Domain.Board{} = new_board) do
     Agent.get_and_update(pid, fn state ->
       case get_by_board(state.boards, new_board) do
         {:error, _} ->
@@ -48,7 +60,7 @@ defmodule KanbanVisionApi.Agent.Boards do
     end)
   end
 
-  def get_by_id(pid, board_id) do
+  def get_by_id(%Runtime{pid: pid}, board_id) do
     Agent.get(pid, fn state ->
       case Map.get(state.boards, board_id) do
         nil -> {:error, "Board with id: #{board_id} not found"}
@@ -57,11 +69,11 @@ defmodule KanbanVisionApi.Agent.Boards do
     end)
   end
 
-  def get_all(pid) do
+  def get_all(%Runtime{pid: pid}) do
     Agent.get(pid, fn state -> state.boards end)
   end
 
-  def delete(pid, board_id) do
+  def delete(%Runtime{pid: pid}, board_id) do
     Agent.get_and_update(pid, fn state ->
       case Map.get(state.boards, board_id) do
         nil ->
@@ -74,7 +86,7 @@ defmodule KanbanVisionApi.Agent.Boards do
     end)
   end
 
-  def get_all_by_simulation_id(pid, simulation_id) do
+  def get_all_by_simulation_id(%Runtime{pid: pid}, simulation_id) do
     Agent.get(pid, fn state ->
       get_by_simulation_id(state.boards, simulation_id)
     end)

--- a/apps/persistence/lib/kanban_vision_api/agent/boards.ex
+++ b/apps/persistence/lib/kanban_vision_api/agent/boards.ex
@@ -30,12 +30,10 @@ defmodule KanbanVisionApi.Agent.Boards do
 
   # Client
 
-  @spec start_link(t()) :: {:ok, runtime()} | {:error, term()}
+  @spec start_link(t()) :: {:ok, runtime()}
   def start_link(default \\ __MODULE__.new()) do
-    case Agent.start_link(fn -> default end) do
-      {:ok, pid} -> {:ok, %Runtime{pid: pid}}
-      {:error, reason} -> {:error, reason}
-    end
+    {:ok, pid} = Agent.start_link(fn -> default end)
+    {:ok, %Runtime{pid: pid}}
   end
 
   def add(%Runtime{pid: pid}, %KanbanVisionApi.Domain.Board{} = new_board) do

--- a/apps/persistence/lib/kanban_vision_api/agent/boards.ex
+++ b/apps/persistence/lib/kanban_vision_api/agent/boards.ex
@@ -30,11 +30,13 @@ defmodule KanbanVisionApi.Agent.Boards do
 
   # Client
 
-  @spec start_link(t()) :: {:ok, runtime()}
+  @spec start_link(t()) :: Agent.on_start()
   def start_link(default \\ __MODULE__.new()) do
-    {:ok, pid} = Agent.start_link(fn -> default end)
-    {:ok, %Runtime{pid: pid}}
+    Agent.start_link(fn -> default end)
   end
+
+  @spec runtime(pid()) :: runtime()
+  def runtime(pid), do: %Runtime{pid: pid}
 
   def add(%Runtime{pid: pid}, %KanbanVisionApi.Domain.Board{} = new_board) do
     Agent.get_and_update(pid, fn state ->

--- a/apps/persistence/lib/kanban_vision_api/agent/organizations.ex
+++ b/apps/persistence/lib/kanban_vision_api/agent/organizations.ex
@@ -30,12 +30,10 @@ defmodule KanbanVisionApi.Agent.Organizations do
 
   # Client
 
-  @spec start_link(t()) :: {:ok, runtime()} | {:error, term()}
+  @spec start_link(t()) :: {:ok, runtime()}
   def start_link(default \\ __MODULE__.new()) do
-    case Agent.start_link(fn -> default end) do
-      {:ok, pid} -> {:ok, %Runtime{pid: pid}}
-      {:error, reason} -> {:error, reason}
-    end
+    {:ok, pid} = Agent.start_link(fn -> default end)
+    {:ok, %Runtime{pid: pid}}
   end
 
   def get_all(%Runtime{pid: pid}) do

--- a/apps/persistence/lib/kanban_vision_api/agent/organizations.ex
+++ b/apps/persistence/lib/kanban_vision_api/agent/organizations.ex
@@ -5,12 +5,21 @@ defmodule KanbanVisionApi.Agent.Organizations do
 
   @behaviour KanbanVisionApi.Domain.Ports.OrganizationRepository
 
+  defmodule Runtime do
+    @moduledoc false
+
+    @enforce_keys [:pid]
+    defstruct [:pid]
+  end
+
   defstruct [:id, :organizations]
 
   @type t :: %__MODULE__{
           id: String.t(),
           organizations: map()
         }
+
+  @opaque runtime :: %Runtime{pid: pid()}
 
   def new(organizations \\ %{}, id \\ UUID.uuid4()) do
     %__MODULE__{
@@ -21,16 +30,19 @@ defmodule KanbanVisionApi.Agent.Organizations do
 
   # Client
 
-  @spec start_link(t()) :: Agent.on_start()
+  @spec start_link(t()) :: {:ok, runtime()} | {:error, term()}
   def start_link(default \\ __MODULE__.new()) do
-    Agent.start_link(fn -> default end)
+    case Agent.start_link(fn -> default end) do
+      {:ok, pid} -> {:ok, %Runtime{pid: pid}}
+      {:error, reason} -> {:error, reason}
+    end
   end
 
-  def get_all(pid) do
+  def get_all(%Runtime{pid: pid}) do
     Agent.get(pid, fn state -> state.organizations end)
   end
 
-  def get_by_id(pid, domain_id) do
+  def get_by_id(%Runtime{pid: pid}, domain_id) do
     Agent.get(pid, fn state ->
       case Map.get(state.organizations, domain_id) do
         nil -> {:error, "Organization with id: #{domain_id} not found"}
@@ -39,13 +51,13 @@ defmodule KanbanVisionApi.Agent.Organizations do
     end)
   end
 
-  def get_by_name(pid, domain_name) do
+  def get_by_name(%Runtime{pid: pid}, domain_name) do
     Agent.get(pid, fn state ->
       internal_get_by_name(state.organizations, domain_name)
     end)
   end
 
-  def add(pid, %KanbanVisionApi.Domain.Organization{} = new_organization) do
+  def add(%Runtime{pid: pid}, %KanbanVisionApi.Domain.Organization{} = new_organization) do
     Agent.get_and_update(pid, fn state ->
       case internal_get_by_name(state.organizations, new_organization.name) do
         {:error, _} ->
@@ -59,7 +71,7 @@ defmodule KanbanVisionApi.Agent.Organizations do
     end)
   end
 
-  def delete(pid, domain_id) do
+  def delete(%Runtime{pid: pid}, domain_id) do
     Agent.get_and_update(pid, fn state ->
       case Map.get(state.organizations, domain_id) do
         nil ->

--- a/apps/persistence/lib/kanban_vision_api/agent/organizations.ex
+++ b/apps/persistence/lib/kanban_vision_api/agent/organizations.ex
@@ -30,11 +30,13 @@ defmodule KanbanVisionApi.Agent.Organizations do
 
   # Client
 
-  @spec start_link(t()) :: {:ok, runtime()}
+  @spec start_link(t()) :: Agent.on_start()
   def start_link(default \\ __MODULE__.new()) do
-    {:ok, pid} = Agent.start_link(fn -> default end)
-    {:ok, %Runtime{pid: pid}}
+    Agent.start_link(fn -> default end)
   end
+
+  @spec runtime(pid()) :: runtime()
+  def runtime(pid), do: %Runtime{pid: pid}
 
   def get_all(%Runtime{pid: pid}) do
     Agent.get(pid, fn state -> state.organizations end)

--- a/apps/persistence/lib/kanban_vision_api/agent/simulations.ex
+++ b/apps/persistence/lib/kanban_vision_api/agent/simulations.ex
@@ -30,11 +30,13 @@ defmodule KanbanVisionApi.Agent.Simulations do
 
   # Client
 
-  @spec start_link(t()) :: {:ok, runtime()}
+  @spec start_link(t()) :: Agent.on_start()
   def start_link(default \\ __MODULE__.new()) do
-    {:ok, pid} = Agent.start_link(fn -> default end)
-    {:ok, %Runtime{pid: pid}}
+    Agent.start_link(fn -> default end)
   end
+
+  @spec runtime(pid()) :: runtime()
+  def runtime(pid), do: %Runtime{pid: pid}
 
   def get_all(%Runtime{pid: pid}) do
     Agent.get(pid, fn state -> state.simulations_by_organization end)

--- a/apps/persistence/lib/kanban_vision_api/agent/simulations.ex
+++ b/apps/persistence/lib/kanban_vision_api/agent/simulations.ex
@@ -5,12 +5,21 @@ defmodule KanbanVisionApi.Agent.Simulations do
 
   @behaviour KanbanVisionApi.Domain.Ports.SimulationRepository
 
+  defmodule Runtime do
+    @moduledoc false
+
+    @enforce_keys [:pid]
+    defstruct [:pid]
+  end
+
   defstruct [:id, :simulations_by_organization]
 
   @type t :: %__MODULE__{
           id: String.t(),
           simulations_by_organization: map()
         }
+
+  @opaque runtime :: %Runtime{pid: pid()}
 
   def new(simulations_by_organization \\ %{}, id \\ UUID.uuid4()) do
     %__MODULE__{
@@ -21,16 +30,19 @@ defmodule KanbanVisionApi.Agent.Simulations do
 
   # Client
 
-  @spec start_link(t()) :: Agent.on_start()
+  @spec start_link(t()) :: {:ok, runtime()} | {:error, term()}
   def start_link(default \\ __MODULE__.new()) do
-    Agent.start_link(fn -> default end)
+    case Agent.start_link(fn -> default end) do
+      {:ok, pid} -> {:ok, %Runtime{pid: pid}}
+      {:error, reason} -> {:error, reason}
+    end
   end
 
-  def get_all(pid) do
+  def get_all(%Runtime{pid: pid}) do
     Agent.get(pid, fn state -> state.simulations_by_organization end)
   end
 
-  def add(pid, %KanbanVisionApi.Domain.Simulation{} = new_simulation) do
+  def add(%Runtime{pid: pid}, %KanbanVisionApi.Domain.Simulation{} = new_simulation) do
     Agent.get_and_update(pid, fn state ->
       result =
         internal_find_by_org_and_name(
@@ -77,7 +89,7 @@ defmodule KanbanVisionApi.Agent.Simulations do
     end)
   end
 
-  def delete(pid, simulation_id) do
+  def delete(%Runtime{pid: pid}, simulation_id) do
     Agent.get_and_update(pid, fn state ->
       case internal_find_by_id(state, simulation_id) do
         {:ok, simulation} ->
@@ -90,7 +102,11 @@ defmodule KanbanVisionApi.Agent.Simulations do
     end)
   end
 
-  def get_by_organization_id_and_simulation_name(pid, organization_id, simulation_name) do
+  def get_by_organization_id_and_simulation_name(
+        %Runtime{pid: pid},
+        organization_id,
+        simulation_name
+      ) do
     Agent.get(pid, fn state ->
       internal_find_by_org_and_name(state, organization_id, simulation_name)
     end)

--- a/apps/persistence/lib/kanban_vision_api/agent/simulations.ex
+++ b/apps/persistence/lib/kanban_vision_api/agent/simulations.ex
@@ -30,12 +30,10 @@ defmodule KanbanVisionApi.Agent.Simulations do
 
   # Client
 
-  @spec start_link(t()) :: {:ok, runtime()} | {:error, term()}
+  @spec start_link(t()) :: {:ok, runtime()}
   def start_link(default \\ __MODULE__.new()) do
-    case Agent.start_link(fn -> default end) do
-      {:ok, pid} -> {:ok, %Runtime{pid: pid}}
-      {:error, reason} -> {:error, reason}
-    end
+    {:ok, pid} = Agent.start_link(fn -> default end)
+    {:ok, %Runtime{pid: pid}}
   end
 
   def get_all(%Runtime{pid: pid}) do

--- a/apps/persistence/test/kanban_vision_api/agent/board_repository_contract_test.exs
+++ b/apps/persistence/test/kanban_vision_api/agent/board_repository_contract_test.exs
@@ -13,7 +13,8 @@ defmodule KanbanVisionApi.Agent.BoardRepositoryContractTest do
 
   describe "BoardRepository contract" do
     setup do
-      {:ok, repository_runtime} = Boards.start_link()
+      {:ok, repository_pid} = Boards.start_link()
+      repository_runtime = Boards.runtime(repository_pid)
       [repository_runtime: repository_runtime]
     end
 

--- a/apps/persistence/test/kanban_vision_api/agent/board_repository_contract_test.exs
+++ b/apps/persistence/test/kanban_vision_api/agent/board_repository_contract_test.exs
@@ -13,57 +13,59 @@ defmodule KanbanVisionApi.Agent.BoardRepositoryContractTest do
 
   describe "BoardRepository contract" do
     setup do
-      {:ok, pid} = Boards.start_link()
-      [repository_pid: pid]
+      {:ok, repository_runtime} = Boards.start_link()
+      [repository_runtime: repository_runtime]
     end
 
-    test "implements get_all/1 callback", %{repository_pid: pid} do
+    test "implements get_all/1 callback", %{repository_runtime: repository_runtime} do
       assert function_exported?(Boards, :get_all, 1)
-      assert is_map(Boards.get_all(pid))
+      assert is_map(Boards.get_all(repository_runtime))
     end
 
-    test "implements get_by_id/2 callback", %{repository_pid: pid} do
+    test "implements get_by_id/2 callback", %{repository_runtime: repository_runtime} do
       assert function_exported?(Boards, :get_by_id, 2)
 
       board = Board.new("TestBoard", "sim-123")
-      {:ok, created} = Boards.add(pid, board)
+      {:ok, created} = Boards.add(repository_runtime, board)
 
-      assert {:ok, ^created} = Boards.get_by_id(pid, created.id)
-      assert {:error, _} = Boards.get_by_id(pid, "non-existent-id")
+      assert {:ok, ^created} = Boards.get_by_id(repository_runtime, created.id)
+      assert {:error, _} = Boards.get_by_id(repository_runtime, "non-existent-id")
     end
 
-    test "implements add/2 callback", %{repository_pid: pid} do
+    test "implements add/2 callback", %{repository_runtime: repository_runtime} do
       assert function_exported?(Boards, :add, 2)
 
       board = Board.new("NewBoard", "sim-456")
-      assert {:ok, added} = Boards.add(pid, board)
+      assert {:ok, added} = Boards.add(repository_runtime, board)
       assert added.id == board.id
       assert added.name == "NewBoard"
 
       duplicate = Board.new("NewBoard", "sim-456")
-      assert {:error, _} = Boards.add(pid, duplicate)
+      assert {:error, _} = Boards.add(repository_runtime, duplicate)
     end
 
-    test "implements delete/2 callback", %{repository_pid: pid} do
+    test "implements delete/2 callback", %{repository_runtime: repository_runtime} do
       assert function_exported?(Boards, :delete, 2)
 
       board = Board.new("ToDelete", "sim-789")
-      {:ok, created} = Boards.add(pid, board)
+      {:ok, created} = Boards.add(repository_runtime, board)
 
-      assert {:ok, deleted} = Boards.delete(pid, created.id)
+      assert {:ok, deleted} = Boards.delete(repository_runtime, created.id)
       assert deleted.id == created.id
 
-      assert {:error, _} = Boards.delete(pid, "non-existent-id")
+      assert {:error, _} = Boards.delete(repository_runtime, "non-existent-id")
     end
 
-    test "implements get_all_by_simulation_id/2 callback", %{repository_pid: pid} do
+    test "implements get_all_by_simulation_id/2 callback", %{
+      repository_runtime: repository_runtime
+    } do
       assert function_exported?(Boards, :get_all_by_simulation_id, 2)
 
       board = Board.new("SimBoard", "sim-abc")
-      {:ok, _} = Boards.add(pid, board)
+      {:ok, _} = Boards.add(repository_runtime, board)
 
-      assert {:ok, [_]} = Boards.get_all_by_simulation_id(pid, "sim-abc")
-      assert {:error, _} = Boards.get_all_by_simulation_id(pid, "non-existent")
+      assert {:ok, [_]} = Boards.get_all_by_simulation_id(repository_runtime, "sim-abc")
+      assert {:error, _} = Boards.get_all_by_simulation_id(repository_runtime, "non-existent")
     end
 
     test "satisfies @behaviour BoardRepository" do

--- a/apps/persistence/test/kanban_vision_api/agent/boards_test.exs
+++ b/apps/persistence/test/kanban_vision_api/agent/boards_test.exs
@@ -128,7 +128,8 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
   defp prepare_empty_context(_context) do
     boards_domain = Boards.new()
     workflow_domain = Workflow.new()
-    {:ok, repository_runtime} = Boards.start_link(boards_domain)
+    {:ok, repository_pid} = Boards.start_link(boards_domain)
+    repository_runtime = Boards.runtime(repository_pid)
 
     [
       repository_runtime: repository_runtime,
@@ -140,7 +141,8 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
   defp prepare_context_with_boards(_context) do
     board = Board.new("Dev Board", "sim-123")
     boards_domain = Boards.new(%{board.id => board})
-    {:ok, repository_runtime} = Boards.start_link(boards_domain)
+    {:ok, repository_pid} = Boards.start_link(boards_domain)
+    repository_runtime = Boards.runtime(repository_pid)
 
     [
       repository_runtime: repository_runtime,

--- a/apps/persistence/test/kanban_vision_api/agent/boards_test.exs
+++ b/apps/persistence/test/kanban_vision_api/agent/boards_test.exs
@@ -12,43 +12,43 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
     @tag :domain_boards
     test "should not have any boards by any simulation",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            boards: _boards
          } = _context do
       template = %{}
-      assert Boards.get_all(pid) == template
+      assert Boards.get_all(repository_runtime) == template
     end
 
     @tag :domain_boards
     test "should not have any board by simulation_id",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            boards: _boards
          } = _context do
       template = {:error, "Boards by simulation_id: nada not found"}
-      assert Boards.get_all_by_simulation_id(pid, "nada") == template
+      assert Boards.get_all_by_simulation_id(repository_runtime, "nada") == template
     end
 
     @tag :domain_boards
     test "should be able to add a new board",
          %{
-           actor_pid: pid
+           repository_runtime: repository_runtime
          } = _context do
       board = Board.new("Dev Board", "sim-123")
-      assert {:ok, ^board} = Boards.add(pid, board)
-      assert %{} = Boards.get_all(pid)
+      assert {:ok, ^board} = Boards.add(repository_runtime, board)
+      assert %{} = Boards.get_all(repository_runtime)
     end
 
     @tag :domain_boards
     test "should not add a board with same name and simulation_id",
          %{
-           actor_pid: pid
+           repository_runtime: repository_runtime
          } = _context do
       board = Board.new("Dev Board", "sim-123")
-      assert {:ok, ^board} = Boards.add(pid, board)
+      assert {:ok, ^board} = Boards.add(repository_runtime, board)
 
       duplicate = Board.new("Dev Board", "sim-123")
-      assert {:error, _msg} = Boards.add(pid, duplicate)
+      assert {:error, _msg} = Boards.add(repository_runtime, duplicate)
     end
   end
 
@@ -58,11 +58,11 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
     @tag :domain_boards
     test "should get boards by simulation_id",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            board: board
          } = _context do
       assert {:ok, boards} =
-               Boards.get_all_by_simulation_id(pid, board.simulation_id)
+               Boards.get_all_by_simulation_id(repository_runtime, board.simulation_id)
 
       assert length(boards) == 1
     end
@@ -70,68 +70,68 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
     @tag :domain_boards
     test "should allow adding board with a different name for the same simulation_id",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            board: board
          } = _context do
       new_board = Board.new("QA Board", board.simulation_id)
-      assert {:ok, ^new_board} = Boards.add(pid, new_board)
-      assert 2 = map_size(Boards.get_all(pid))
+      assert {:ok, ^new_board} = Boards.add(repository_runtime, new_board)
+      assert 2 = map_size(Boards.get_all(repository_runtime))
     end
 
     @tag :domain_boards
     test "should return error for unknown simulation_id",
          %{
-           actor_pid: pid
+           repository_runtime: repository_runtime
          } = _context do
       assert {:error, _msg} =
-               Boards.get_all_by_simulation_id(pid, "unknown")
+               Boards.get_all_by_simulation_id(repository_runtime, "unknown")
     end
 
     @tag :domain_boards
     test "should get a board by its id",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            board: board
          } = _context do
-      assert {:ok, ^board} = Boards.get_by_id(pid, board.id)
+      assert {:ok, ^board} = Boards.get_by_id(repository_runtime, board.id)
     end
 
     @tag :domain_boards
     test "should return error when getting board by unknown id",
          %{
-           actor_pid: pid
+           repository_runtime: repository_runtime
          } = _context do
       assert {:error, "Board with id: unknown-id not found"} =
-               Boards.get_by_id(pid, "unknown-id")
+               Boards.get_by_id(repository_runtime, "unknown-id")
     end
 
     @tag :domain_boards
     test "should delete a board by its id",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            board: board
          } = _context do
-      assert {:ok, ^board} = Boards.delete(pid, board.id)
-      assert %{} == Boards.get_all(pid)
+      assert {:ok, ^board} = Boards.delete(repository_runtime, board.id)
+      assert %{} == Boards.get_all(repository_runtime)
     end
 
     @tag :domain_boards
     test "should return error when deleting board with unknown id",
          %{
-           actor_pid: pid
+           repository_runtime: repository_runtime
          } = _context do
       assert {:error, "Board with id: unknown-id not found"} =
-               Boards.delete(pid, "unknown-id")
+               Boards.delete(repository_runtime, "unknown-id")
     end
   end
 
   defp prepare_empty_context(_context) do
     boards_domain = Boards.new()
     workflow_domain = Workflow.new()
-    {:ok, pid} = Boards.start_link(boards_domain)
+    {:ok, repository_runtime} = Boards.start_link(boards_domain)
 
     [
-      actor_pid: pid,
+      repository_runtime: repository_runtime,
       boards: boards_domain,
       workflow: workflow_domain
     ]
@@ -140,10 +140,10 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
   defp prepare_context_with_boards(_context) do
     board = Board.new("Dev Board", "sim-123")
     boards_domain = Boards.new(%{board.id => board})
-    {:ok, pid} = Boards.start_link(boards_domain)
+    {:ok, repository_runtime} = Boards.start_link(boards_domain)
 
     [
-      actor_pid: pid,
+      repository_runtime: repository_runtime,
       boards: boards_domain,
       board: board
     ]

--- a/apps/persistence/test/kanban_vision_api/agent/organization_repository_contract_test.exs
+++ b/apps/persistence/test/kanban_vision_api/agent/organization_repository_contract_test.exs
@@ -13,59 +13,59 @@ defmodule KanbanVisionApi.Agent.OrganizationRepositoryContractTest do
 
   describe "OrganizationRepository contract" do
     setup do
-      {:ok, pid} = Organizations.start_link()
-      [repository_pid: pid]
+      {:ok, repository_runtime} = Organizations.start_link()
+      [repository_runtime: repository_runtime]
     end
 
-    test "implements get_all/1 callback", %{repository_pid: pid} do
+    test "implements get_all/1 callback", %{repository_runtime: repository_runtime} do
       assert function_exported?(Organizations, :get_all, 1)
-      assert is_map(Organizations.get_all(pid))
+      assert is_map(Organizations.get_all(repository_runtime))
     end
 
-    test "implements get_by_id/2 callback", %{repository_pid: pid} do
+    test "implements get_by_id/2 callback", %{repository_runtime: repository_runtime} do
       assert function_exported?(Organizations, :get_by_id, 2)
 
       org = Organization.new("TestOrg")
-      {:ok, created} = Organizations.add(pid, org)
+      {:ok, created} = Organizations.add(repository_runtime, org)
 
-      assert {:ok, ^created} = Organizations.get_by_id(pid, created.id)
-      assert {:error, _} = Organizations.get_by_id(pid, "non-existent-id")
+      assert {:ok, ^created} = Organizations.get_by_id(repository_runtime, created.id)
+      assert {:error, _} = Organizations.get_by_id(repository_runtime, "non-existent-id")
     end
 
-    test "implements get_by_name/2 callback", %{repository_pid: pid} do
+    test "implements get_by_name/2 callback", %{repository_runtime: repository_runtime} do
       assert function_exported?(Organizations, :get_by_name, 2)
 
       org = Organization.new("UniqueOrg")
-      {:ok, created} = Organizations.add(pid, org)
+      {:ok, created} = Organizations.add(repository_runtime, org)
 
-      assert {:ok, [^created]} = Organizations.get_by_name(pid, "UniqueOrg")
-      assert {:error, _} = Organizations.get_by_name(pid, "NonExistentOrg")
+      assert {:ok, [^created]} = Organizations.get_by_name(repository_runtime, "UniqueOrg")
+      assert {:error, _} = Organizations.get_by_name(repository_runtime, "NonExistentOrg")
     end
 
-    test "implements add/2 callback", %{repository_pid: pid} do
+    test "implements add/2 callback", %{repository_runtime: repository_runtime} do
       assert function_exported?(Organizations, :add, 2)
 
       org = Organization.new("NewOrg")
-      assert {:ok, added} = Organizations.add(pid, org)
+      assert {:ok, added} = Organizations.add(repository_runtime, org)
       assert added.id == org.id
       assert added.name == "NewOrg"
 
       # Should reject duplicate names
       duplicate = Organization.new("NewOrg")
-      assert {:error, _} = Organizations.add(pid, duplicate)
+      assert {:error, _} = Organizations.add(repository_runtime, duplicate)
     end
 
-    test "implements delete/2 callback", %{repository_pid: pid} do
+    test "implements delete/2 callback", %{repository_runtime: repository_runtime} do
       assert function_exported?(Organizations, :delete, 2)
 
       org = Organization.new("ToDelete")
-      {:ok, created} = Organizations.add(pid, org)
+      {:ok, created} = Organizations.add(repository_runtime, org)
 
-      assert {:ok, deleted} = Organizations.delete(pid, created.id)
+      assert {:ok, deleted} = Organizations.delete(repository_runtime, created.id)
       assert deleted.id == created.id
 
       # Should fail on non-existent ID
-      assert {:error, _} = Organizations.delete(pid, "non-existent-id")
+      assert {:error, _} = Organizations.delete(repository_runtime, "non-existent-id")
     end
 
     test "satisfies @behaviour OrganizationRepository" do

--- a/apps/persistence/test/kanban_vision_api/agent/organization_repository_contract_test.exs
+++ b/apps/persistence/test/kanban_vision_api/agent/organization_repository_contract_test.exs
@@ -13,7 +13,8 @@ defmodule KanbanVisionApi.Agent.OrganizationRepositoryContractTest do
 
   describe "OrganizationRepository contract" do
     setup do
-      {:ok, repository_runtime} = Organizations.start_link()
+      {:ok, repository_pid} = Organizations.start_link()
+      repository_runtime = Organizations.runtime(repository_pid)
       [repository_runtime: repository_runtime]
     end
 

--- a/apps/persistence/test/kanban_vision_api/agent/organizations_test.exs
+++ b/apps/persistence/test/kanban_vision_api/agent/organizations_test.exs
@@ -11,42 +11,42 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
     @tag :domain_organizations
     test "should not have any organization",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            organizations: _organizations
          } = _context do
       template = %{}
-      assert Organizations.get_all(pid) == template
+      assert Organizations.get_all(repository_runtime) == template
     end
 
     @tag :domain_organizations
     test "should be able to add new organization",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            organizations: _organizations
          } = _context do
       domain = Organization.new("ExampleOrg")
-      assert Organizations.add(pid, domain) == {:ok, domain}
+      assert Organizations.add(repository_runtime, domain) == {:ok, domain}
     end
 
     @tag :domain_organizations
     test "should be able to delete an existent organization",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            organizations: _organizations
          } = _context do
       domain = Organization.new("ExampleOrg")
-      assert Organizations.add(pid, domain) == {:ok, domain}
-      assert Organizations.delete(pid, domain.id) == {:ok, domain}
+      assert Organizations.add(repository_runtime, domain) == {:ok, domain}
+      assert Organizations.delete(repository_runtime, domain.id) == {:ok, domain}
     end
 
     @tag :domain_organizations
     test "should not be able to delete a non-existent organization",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            organizations: _organizations
          } = _context do
       template = {:error, "Organization with id: nada not found"}
-      assert Organizations.delete(pid, :nada) == template
+      assert Organizations.delete(repository_runtime, :nada) == template
     end
   end
 
@@ -56,75 +56,75 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
     @tag :domain_organizations
     test "should has one organization",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            organizations: _organizations,
            domain: my_domain
          } = _context do
       template = %{my_domain.id => my_domain}
 
-      assert Organizations.get_all(pid) == template
+      assert Organizations.get_all(repository_runtime) == template
     end
 
     @tag :domain_organizations
     test "should be possible to find the organization by the id",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            organizations: _organizations,
            domain: domain
          } = _context do
-      assert Organizations.get_by_id(pid, domain.id) == {:ok, domain}
+      assert Organizations.get_by_id(repository_runtime, domain.id) == {:ok, domain}
     end
 
     @tag :domain_organizations
     test "should be possible to find the organization by the name",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            organizations: _organizations,
            domain: domain
          } = _context do
-      assert Organizations.get_by_name(pid, domain.name) == {:ok, [domain]}
+      assert Organizations.get_by_name(repository_runtime, domain.name) == {:ok, [domain]}
     end
 
     @tag :domain_organizations
     test "should not be possible to find the organization by the wrong id",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            organizations: _organizations,
            domain: _domain
          } = _context do
       template = {:error, "Organization with id: nada not found"}
-      assert Organizations.get_by_id(pid, :nada) == template
+      assert Organizations.get_by_id(repository_runtime, :nada) == template
     end
 
     @tag :domain_organizations
     test "should no be possible to find the organization by the wrong name",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            organizations: _organizations,
            domain: _domain
          } = _context do
       template = {:error, "Organization with name: Invalid Name not found"}
-      assert Organizations.get_by_name(pid, "Invalid Name") == template
+      assert Organizations.get_by_name(repository_runtime, "Invalid Name") == template
     end
 
     @tag :domain_organizations
     test "should no be possible to add one organization with the name already exist",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            organizations: _organizations,
            domain: domain
          } = _context do
       template = {:error, "Organization with name: ExampleOrg already exist"}
-      assert Organizations.add(pid, domain) == template
+      assert Organizations.add(repository_runtime, domain) == template
     end
   end
 
   defp prepare_empty_context(_context) do
     organizations_domain = Organizations.new()
-    {:ok, pid} = Organizations.start_link(organizations_domain)
+    {:ok, repository_runtime} = Organizations.start_link(organizations_domain)
 
     [
-      actor_pid: pid,
+      repository_runtime: repository_runtime,
       organizations: organizations_domain
     ]
   end
@@ -135,10 +135,10 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
     initial_state =
       Organizations.new(%{organization_domain.id => organization_domain})
 
-    {:ok, pid} = Organizations.start_link(initial_state)
+    {:ok, repository_runtime} = Organizations.start_link(initial_state)
 
     [
-      actor_pid: pid,
+      repository_runtime: repository_runtime,
       organizations: initial_state,
       domain: organization_domain
     ]

--- a/apps/persistence/test/kanban_vision_api/agent/organizations_test.exs
+++ b/apps/persistence/test/kanban_vision_api/agent/organizations_test.exs
@@ -121,7 +121,8 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
 
   defp prepare_empty_context(_context) do
     organizations_domain = Organizations.new()
-    {:ok, repository_runtime} = Organizations.start_link(organizations_domain)
+    {:ok, repository_pid} = Organizations.start_link(organizations_domain)
+    repository_runtime = Organizations.runtime(repository_pid)
 
     [
       repository_runtime: repository_runtime,
@@ -135,7 +136,8 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
     initial_state =
       Organizations.new(%{organization_domain.id => organization_domain})
 
-    {:ok, repository_runtime} = Organizations.start_link(initial_state)
+    {:ok, repository_pid} = Organizations.start_link(initial_state)
+    repository_runtime = Organizations.runtime(repository_pid)
 
     [
       repository_runtime: repository_runtime,

--- a/apps/persistence/test/kanban_vision_api/agent/simulation_repository_contract_test.exs
+++ b/apps/persistence/test/kanban_vision_api/agent/simulation_repository_contract_test.exs
@@ -13,40 +13,44 @@ defmodule KanbanVisionApi.Agent.SimulationRepositoryContractTest do
 
   describe "SimulationRepository contract" do
     setup do
-      {:ok, pid} = Simulations.start_link()
-      [repository_pid: pid]
+      {:ok, repository_runtime} = Simulations.start_link()
+      [repository_runtime: repository_runtime]
     end
 
-    test "implements get_all/1 callback", %{repository_pid: pid} do
+    test "implements get_all/1 callback", %{repository_runtime: repository_runtime} do
       assert function_exported?(Simulations, :get_all, 1)
-      assert is_map(Simulations.get_all(pid))
+      assert is_map(Simulations.get_all(repository_runtime))
     end
 
-    test "implements add/2 callback", %{repository_pid: pid} do
+    test "implements add/2 callback", %{repository_runtime: repository_runtime} do
       assert function_exported?(Simulations, :add, 2)
 
       org_id = UUID.uuid4()
       sim = Simulation.new("TestSim", "Description", org_id)
-      assert {:ok, added} = Simulations.add(pid, sim)
+      assert {:ok, added} = Simulations.add(repository_runtime, sim)
       assert added.id == sim.id
       assert added.name == "TestSim"
     end
 
     test "implements get_by_organization_id_and_simulation_name/3 callback", %{
-      repository_pid: pid
+      repository_runtime: repository_runtime
     } do
       assert function_exported?(Simulations, :get_by_organization_id_and_simulation_name, 3)
 
       org_id = UUID.uuid4()
       sim = Simulation.new("FindableSim", "Description", org_id)
-      {:ok, created} = Simulations.add(pid, sim)
+      {:ok, created} = Simulations.add(repository_runtime, sim)
 
       assert {:ok, ^created} =
-               Simulations.get_by_organization_id_and_simulation_name(pid, org_id, "FindableSim")
+               Simulations.get_by_organization_id_and_simulation_name(
+                 repository_runtime,
+                 org_id,
+                 "FindableSim"
+               )
 
       assert {:error, _} =
                Simulations.get_by_organization_id_and_simulation_name(
-                 pid,
+                 repository_runtime,
                  org_id,
                  "NonExistentSim"
                )

--- a/apps/persistence/test/kanban_vision_api/agent/simulation_repository_contract_test.exs
+++ b/apps/persistence/test/kanban_vision_api/agent/simulation_repository_contract_test.exs
@@ -13,7 +13,8 @@ defmodule KanbanVisionApi.Agent.SimulationRepositoryContractTest do
 
   describe "SimulationRepository contract" do
     setup do
-      {:ok, repository_runtime} = Simulations.start_link()
+      {:ok, repository_pid} = Simulations.start_link()
+      repository_runtime = Simulations.runtime(repository_pid)
       [repository_runtime: repository_runtime]
     end
 

--- a/apps/persistence/test/kanban_vision_api/agent/simulations_test.exs
+++ b/apps/persistence/test/kanban_vision_api/agent/simulations_test.exs
@@ -12,19 +12,19 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
     @tag :domain_simulations
     test "should not have any simulation for any organization",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            simulations: _simulations,
            organization: _organization
          } = _context do
       template = %{}
 
-      assert Simulations.get_all(pid) == template
+      assert Simulations.get_all(repository_runtime) == template
     end
 
     @tag :domain_simulations
     test "should be able to add a new simulation to a specific organization",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            simulations: _simulations,
            organization: organization
          } = _context do
@@ -35,7 +35,7 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
           organization.id
         )
 
-      assert Simulations.add(pid, simulation_domain) ==
+      assert Simulations.add(repository_runtime, simulation_domain) ==
                {:ok, simulation_domain}
     end
   end
@@ -46,20 +46,20 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
     @tag :domain_simulations
     test "should be able to get all simulations for a specific organization",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            simulations: _simulations,
            simulation: simulation,
            organization: organization
          } = _context do
       template = %{organization.id => %{simulation.id => simulation}}
 
-      assert Simulations.get_all(pid) == template
+      assert Simulations.get_all(repository_runtime) == template
     end
 
     @tag :domain_simulations
     test "should be able to add a new simulation to a specific organization",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            simulations: _simulations,
            simulation: simulation,
            organization: organization
@@ -71,24 +71,24 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
           organization.id
         )
 
-      assert Simulations.add(pid, new_simulation) == {:ok, new_simulation}
+      assert Simulations.add(repository_runtime, new_simulation) == {:ok, new_simulation}
 
       template = %{
         organization.id => %{new_simulation.id => new_simulation, simulation.id => simulation}
       }
 
-      assert Simulations.get_all(pid) == template
+      assert Simulations.get_all(repository_runtime) == template
     end
 
     @tag :domain_simulations
     test "Try to add a simulation that already exists",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            simulations: _simulations,
            simulation: simulation,
            organization: _organization
          } = _context do
-      assert Simulations.add(pid, simulation) == {
+      assert Simulations.add(repository_runtime, simulation) == {
                :error,
                """
                Simulation with organization_id: #{simulation.organization_id}
@@ -100,14 +100,14 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
     @tag :domain_simulations
     test "try to find a simulation on a non existent organization",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            simulations: _simulations,
            organization: _organization
          } = _context do
       template = {:error, "Simulation with organization id: INVALID not found"}
 
       assert Simulations.get_by_organization_id_and_simulation_name(
-               pid,
+               repository_runtime,
                "INVALID",
                "Simulation Name"
              ) == template
@@ -116,13 +116,13 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
     @tag :domain_simulations
     test "try to find a simulation by name that does not exist",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            organization: organization
          } = _context do
       template = {:error, "Simulation with name: Missing Simulation not found"}
 
       assert Simulations.get_by_organization_id_and_simulation_name(
-               pid,
+               repository_runtime,
                organization.id,
                "Missing Simulation"
              ) == template
@@ -131,36 +131,36 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
     @tag :domain_simulations
     test "should delete a simulation by its id",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            simulation: simulation
          } = _context do
-      assert {:ok, ^simulation} = Simulations.delete(pid, simulation.id)
-      assert %{} == Simulations.get_all(pid)
+      assert {:ok, ^simulation} = Simulations.delete(repository_runtime, simulation.id)
+      assert %{} == Simulations.get_all(repository_runtime)
     end
 
     @tag :domain_simulations
     test "should return error when deleting simulation with unknown id",
          %{
-           actor_pid: pid
+           repository_runtime: repository_runtime
          } = _context do
       assert {:error, "Simulation with id: unknown-id not found"} =
-               Simulations.delete(pid, "unknown-id")
+               Simulations.delete(repository_runtime, "unknown-id")
     end
 
     @tag :domain_simulations
     test "should delete one simulation and keep others in same organization",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            simulation: simulation,
            organization: organization
          } = _context do
       other_simulation =
         Simulation.new("OtherSim", "OtherDesc", organization.id)
 
-      assert {:ok, ^other_simulation} = Simulations.add(pid, other_simulation)
-      assert {:ok, ^simulation} = Simulations.delete(pid, simulation.id)
+      assert {:ok, ^other_simulation} = Simulations.add(repository_runtime, other_simulation)
+      assert {:ok, ^simulation} = Simulations.delete(repository_runtime, simulation.id)
 
-      remaining = Simulations.get_all(pid)
+      remaining = Simulations.get_all(repository_runtime)
       assert map_size(remaining[organization.id]) == 1
       assert Map.has_key?(remaining[organization.id], other_simulation.id)
     end
@@ -172,13 +172,13 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
     @tag :domain_simulations
     test "should return error for missing simulations on existing organization",
          %{
-           actor_pid: pid,
+           repository_runtime: repository_runtime,
            organization: organization
          } = _context do
       template = {:error, "Simulation with organization id: #{organization.id} not found"}
 
       assert Simulations.get_by_organization_id_and_simulation_name(
-               pid,
+               repository_runtime,
                organization.id,
                "Any Simulation"
              ) == template
@@ -188,10 +188,10 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
   defp prepare_empty_context(_context) do
     simulations_domain = Simulations.new()
     organization_domain = Organization.new("ExampleOrg")
-    {:ok, pid} = Simulations.start_link(simulations_domain)
+    {:ok, repository_runtime} = Simulations.start_link(simulations_domain)
 
     [
-      actor_pid: pid,
+      repository_runtime: repository_runtime,
       simulations: simulations_domain,
       organization: organization_domain
     ]
@@ -213,10 +213,10 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
 
     simulations_domain = Simulations.new(simulations_by_organization)
 
-    {:ok, pid} = Simulations.start_link(simulations_domain)
+    {:ok, repository_runtime} = Simulations.start_link(simulations_domain)
 
     [
-      actor_pid: pid,
+      repository_runtime: repository_runtime,
       simulations: simulations_domain,
       simulation: simulation_domain,
       organization: organization_domain
@@ -226,10 +226,10 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
   defp prepare_context_with_empty_org(_context) do
     organization_domain = Organization.new("ExampleOrg")
     simulations_domain = Simulations.new(%{organization_domain.id => %{}})
-    {:ok, pid} = Simulations.start_link(simulations_domain)
+    {:ok, repository_runtime} = Simulations.start_link(simulations_domain)
 
     [
-      actor_pid: pid,
+      repository_runtime: repository_runtime,
       simulations: simulations_domain,
       organization: organization_domain
     ]

--- a/apps/persistence/test/kanban_vision_api/agent/simulations_test.exs
+++ b/apps/persistence/test/kanban_vision_api/agent/simulations_test.exs
@@ -188,7 +188,8 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
   defp prepare_empty_context(_context) do
     simulations_domain = Simulations.new()
     organization_domain = Organization.new("ExampleOrg")
-    {:ok, repository_runtime} = Simulations.start_link(simulations_domain)
+    {:ok, repository_pid} = Simulations.start_link(simulations_domain)
+    repository_runtime = Simulations.runtime(repository_pid)
 
     [
       repository_runtime: repository_runtime,
@@ -213,7 +214,8 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
 
     simulations_domain = Simulations.new(simulations_by_organization)
 
-    {:ok, repository_runtime} = Simulations.start_link(simulations_domain)
+    {:ok, repository_pid} = Simulations.start_link(simulations_domain)
+    repository_runtime = Simulations.runtime(repository_pid)
 
     [
       repository_runtime: repository_runtime,
@@ -226,7 +228,8 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
   defp prepare_context_with_empty_org(_context) do
     organization_domain = Organization.new("ExampleOrg")
     simulations_domain = Simulations.new(%{organization_domain.id => %{}})
-    {:ok, repository_runtime} = Simulations.start_link(simulations_domain)
+    {:ok, repository_pid} = Simulations.start_link(simulations_domain)
+    repository_runtime = Simulations.runtime(repository_pid)
 
     [
       repository_runtime: repository_runtime,

--- a/apps/usecase/lib/kanban_vision_api/usecase/boards/delete_board.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/boards/delete_board.ex
@@ -9,13 +9,15 @@ defmodule KanbanVisionApi.Usecase.Boards.DeleteBoard do
   require Logger
 
   alias KanbanVisionApi.Domain.Board
+  alias KanbanVisionApi.Domain.Ports.BoardRepository
   alias KanbanVisionApi.Usecase.Board.DeleteBoardCommand
   alias KanbanVisionApi.Usecase.EventEmitter
   alias KanbanVisionApi.Usecase.RepositoryConfig
 
   @type result :: {:ok, Board.t()} | {:error, String.t()}
 
-  @spec execute(DeleteBoardCommand.t(), term(), keyword()) :: result()
+  @spec execute(DeleteBoardCommand.t(), BoardRepository.repository_runtime(), keyword()) ::
+          result()
   def execute(%DeleteBoardCommand{} = cmd, repository_runtime, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
     repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)

--- a/apps/usecase/lib/kanban_vision_api/usecase/boards/delete_board.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/boards/delete_board.ex
@@ -15,8 +15,8 @@ defmodule KanbanVisionApi.Usecase.Boards.DeleteBoard do
 
   @type result :: {:ok, Board.t()} | {:error, String.t()}
 
-  @spec execute(DeleteBoardCommand.t(), pid(), keyword()) :: result()
-  def execute(%DeleteBoardCommand{} = cmd, repository_pid, opts \\ []) do
+  @spec execute(DeleteBoardCommand.t(), term(), keyword()) :: result()
+  def execute(%DeleteBoardCommand{} = cmd, repository_runtime, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
     repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
 
@@ -25,7 +25,7 @@ defmodule KanbanVisionApi.Usecase.Boards.DeleteBoard do
       board_id: cmd.id
     )
 
-    case repository.delete(repository_pid, cmd.id) do
+    case repository.delete(repository_runtime, cmd.id) do
       {:ok, board} ->
         Logger.info("Board deleted successfully",
           correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/organization.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organization.ex
@@ -49,37 +49,41 @@ defmodule KanbanVisionApi.Usecase.Organization do
   @impl true
   def init(opts) do
     repository = Keyword.fetch!(opts, :repository)
-    {:ok, agent_pid} = repository.start_link()
-    {:ok, %{repository_pid: agent_pid, repository: repository}}
+    {:ok, repository_runtime} = repository.start_link()
+    {:ok, %{repository_runtime: repository_runtime, repository: repository}}
   end
 
   @impl true
   def handle_call({:get_all, opts}, _from, state) do
-    result = GetAllOrganizations.execute(state.repository_pid, enrich_opts(opts, state))
+    result = GetAllOrganizations.execute(state.repository_runtime, enrich_opts(opts, state))
     {:reply, result, state}
   end
 
   @impl true
   def handle_call({:get_by_id, query, opts}, _from, state) do
-    result = GetOrganizationById.execute(query, state.repository_pid, enrich_opts(opts, state))
+    result =
+      GetOrganizationById.execute(query, state.repository_runtime, enrich_opts(opts, state))
+
     {:reply, result, state}
   end
 
   @impl true
   def handle_call({:get_by_name, query, opts}, _from, state) do
-    result = GetOrganizationByName.execute(query, state.repository_pid, enrich_opts(opts, state))
+    result =
+      GetOrganizationByName.execute(query, state.repository_runtime, enrich_opts(opts, state))
+
     {:reply, result, state}
   end
 
   @impl true
   def handle_call({:add, cmd, opts}, _from, state) do
-    result = CreateOrganization.execute(cmd, state.repository_pid, enrich_opts(opts, state))
+    result = CreateOrganization.execute(cmd, state.repository_runtime, enrich_opts(opts, state))
     {:reply, result, state}
   end
 
   @impl true
   def handle_call({:delete, cmd, opts}, _from, state) do
-    result = DeleteOrganization.execute(cmd, state.repository_pid, enrich_opts(opts, state))
+    result = DeleteOrganization.execute(cmd, state.repository_runtime, enrich_opts(opts, state))
     {:reply, result, state}
   end
 

--- a/apps/usecase/lib/kanban_vision_api/usecase/organization.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organization.ex
@@ -49,7 +49,8 @@ defmodule KanbanVisionApi.Usecase.Organization do
   @impl true
   def init(opts) do
     repository = Keyword.fetch!(opts, :repository)
-    {:ok, repository_runtime} = repository.start_link()
+    {:ok, repository_pid} = repository.start_link()
+    repository_runtime = repository.runtime(repository_pid)
     {:ok, %{repository_runtime: repository_runtime, repository: repository}}
   end
 

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/create_organization.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/create_organization.ex
@@ -15,8 +15,8 @@ defmodule KanbanVisionApi.Usecase.Organizations.CreateOrganization do
 
   @type result :: {:ok, Organization.t()} | {:error, String.t()}
 
-  @spec execute(CreateOrganizationCommand.t(), pid(), keyword()) :: result()
-  def execute(%CreateOrganizationCommand{} = cmd, repository_pid, opts \\ []) do
+  @spec execute(CreateOrganizationCommand.t(), term(), keyword()) :: result()
+  def execute(%CreateOrganizationCommand{} = cmd, repository_runtime, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
     repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
 
@@ -28,7 +28,7 @@ defmodule KanbanVisionApi.Usecase.Organizations.CreateOrganization do
 
     organization = Organization.new(cmd.name, cmd.tribes)
 
-    case repository.add(repository_pid, organization) do
+    case repository.add(repository_runtime, organization) do
       {:ok, org} ->
         Logger.info("Organization created successfully",
           correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/create_organization.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/create_organization.ex
@@ -9,13 +9,19 @@ defmodule KanbanVisionApi.Usecase.Organizations.CreateOrganization do
   require Logger
 
   alias KanbanVisionApi.Domain.Organization
+  alias KanbanVisionApi.Domain.Ports.OrganizationRepository
   alias KanbanVisionApi.Usecase.EventEmitter
   alias KanbanVisionApi.Usecase.Organization.CreateOrganizationCommand
   alias KanbanVisionApi.Usecase.RepositoryConfig
 
   @type result :: {:ok, Organization.t()} | {:error, String.t()}
 
-  @spec execute(CreateOrganizationCommand.t(), term(), keyword()) :: result()
+  @spec execute(
+          CreateOrganizationCommand.t(),
+          OrganizationRepository.repository_runtime(),
+          keyword()
+        ) ::
+          result()
   def execute(%CreateOrganizationCommand{} = cmd, repository_runtime, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
     repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/delete_organization.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/delete_organization.ex
@@ -9,13 +9,19 @@ defmodule KanbanVisionApi.Usecase.Organizations.DeleteOrganization do
   require Logger
 
   alias KanbanVisionApi.Domain.Organization
+  alias KanbanVisionApi.Domain.Ports.OrganizationRepository
   alias KanbanVisionApi.Usecase.EventEmitter
   alias KanbanVisionApi.Usecase.Organization.DeleteOrganizationCommand
   alias KanbanVisionApi.Usecase.RepositoryConfig
 
   @type result :: {:ok, Organization.t()} | {:error, String.t()}
 
-  @spec execute(DeleteOrganizationCommand.t(), term(), keyword()) :: result()
+  @spec execute(
+          DeleteOrganizationCommand.t(),
+          OrganizationRepository.repository_runtime(),
+          keyword()
+        ) ::
+          result()
   def execute(%DeleteOrganizationCommand{} = cmd, repository_runtime, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
     repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/delete_organization.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/delete_organization.ex
@@ -15,8 +15,8 @@ defmodule KanbanVisionApi.Usecase.Organizations.DeleteOrganization do
 
   @type result :: {:ok, Organization.t()} | {:error, String.t()}
 
-  @spec execute(DeleteOrganizationCommand.t(), pid(), keyword()) :: result()
-  def execute(%DeleteOrganizationCommand{} = cmd, repository_pid, opts \\ []) do
+  @spec execute(DeleteOrganizationCommand.t(), term(), keyword()) :: result()
+  def execute(%DeleteOrganizationCommand{} = cmd, repository_runtime, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
     repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
 
@@ -25,7 +25,7 @@ defmodule KanbanVisionApi.Usecase.Organizations.DeleteOrganization do
       organization_id: cmd.id
     )
 
-    case repository.delete(repository_pid, cmd.id) do
+    case repository.delete(repository_runtime, cmd.id) do
       {:ok, org} ->
         Logger.info("Organization deleted successfully",
           correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_all_organizations.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_all_organizations.ex
@@ -12,14 +12,14 @@ defmodule KanbanVisionApi.Usecase.Organizations.GetAllOrganizations do
 
   @type result :: {:ok, map()}
 
-  @spec execute(pid(), keyword()) :: result()
-  def execute(repository_pid, opts \\ []) do
+  @spec execute(term(), keyword()) :: result()
+  def execute(repository_runtime, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
     repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
 
     Logger.debug("Retrieving all organizations", correlation_id: correlation_id)
 
-    organizations = repository.get_all(repository_pid)
+    organizations = repository.get_all(repository_runtime)
 
     Logger.debug("All organizations retrieved",
       correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_all_organizations.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_all_organizations.ex
@@ -7,12 +7,13 @@ defmodule KanbanVisionApi.Usecase.Organizations.GetAllOrganizations do
 
   require Logger
 
+  alias KanbanVisionApi.Domain.Ports.OrganizationRepository
   alias KanbanVisionApi.Usecase.EventEmitter
   alias KanbanVisionApi.Usecase.RepositoryConfig
 
   @type result :: {:ok, map()}
 
-  @spec execute(term(), keyword()) :: result()
+  @spec execute(OrganizationRepository.repository_runtime(), keyword()) :: result()
   def execute(repository_runtime, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
     repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_id.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_id.ex
@@ -8,12 +8,17 @@ defmodule KanbanVisionApi.Usecase.Organizations.GetOrganizationById do
   require Logger
 
   alias KanbanVisionApi.Domain.Organization
+  alias KanbanVisionApi.Domain.Ports.OrganizationRepository
   alias KanbanVisionApi.Usecase.Organization.GetOrganizationByIdQuery
   alias KanbanVisionApi.Usecase.RepositoryConfig
 
   @type result :: {:ok, Organization.t()} | {:error, String.t()}
 
-  @spec execute(GetOrganizationByIdQuery.t(), term(), keyword()) :: result()
+  @spec execute(
+          GetOrganizationByIdQuery.t(),
+          OrganizationRepository.repository_runtime(),
+          keyword()
+        ) :: result()
   def execute(%GetOrganizationByIdQuery{} = query, repository_runtime, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
     repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_id.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_id.ex
@@ -13,8 +13,8 @@ defmodule KanbanVisionApi.Usecase.Organizations.GetOrganizationById do
 
   @type result :: {:ok, Organization.t()} | {:error, String.t()}
 
-  @spec execute(GetOrganizationByIdQuery.t(), pid(), keyword()) :: result()
-  def execute(%GetOrganizationByIdQuery{} = query, repository_pid, opts \\ []) do
+  @spec execute(GetOrganizationByIdQuery.t(), term(), keyword()) :: result()
+  def execute(%GetOrganizationByIdQuery{} = query, repository_runtime, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
     repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
 
@@ -23,7 +23,7 @@ defmodule KanbanVisionApi.Usecase.Organizations.GetOrganizationById do
       organization_id: query.id
     )
 
-    result = repository.get_by_id(repository_pid, query.id)
+    result = repository.get_by_id(repository_runtime, query.id)
 
     case result do
       {:ok, org} ->

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_name.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_name.ex
@@ -12,8 +12,8 @@ defmodule KanbanVisionApi.Usecase.Organizations.GetOrganizationByName do
 
   @type result :: {:ok, list()} | {:error, String.t()}
 
-  @spec execute(GetOrganizationByNameQuery.t(), pid(), keyword()) :: result()
-  def execute(%GetOrganizationByNameQuery{} = query, repository_pid, opts \\ []) do
+  @spec execute(GetOrganizationByNameQuery.t(), term(), keyword()) :: result()
+  def execute(%GetOrganizationByNameQuery{} = query, repository_runtime, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
     repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
 
@@ -22,7 +22,7 @@ defmodule KanbanVisionApi.Usecase.Organizations.GetOrganizationByName do
       organization_name: query.name
     )
 
-    result = repository.get_by_name(repository_pid, query.name)
+    result = repository.get_by_name(repository_runtime, query.name)
 
     case result do
       {:ok, orgs} ->

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_name.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_name.ex
@@ -7,12 +7,17 @@ defmodule KanbanVisionApi.Usecase.Organizations.GetOrganizationByName do
 
   require Logger
 
+  alias KanbanVisionApi.Domain.Ports.OrganizationRepository
   alias KanbanVisionApi.Usecase.Organization.GetOrganizationByNameQuery
   alias KanbanVisionApi.Usecase.RepositoryConfig
 
   @type result :: {:ok, list()} | {:error, String.t()}
 
-  @spec execute(GetOrganizationByNameQuery.t(), term(), keyword()) :: result()
+  @spec execute(
+          GetOrganizationByNameQuery.t(),
+          OrganizationRepository.repository_runtime(),
+          keyword()
+        ) :: result()
   def execute(%GetOrganizationByNameQuery{} = query, repository_runtime, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
     repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulation.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulation.ex
@@ -43,7 +43,8 @@ defmodule KanbanVisionApi.Usecase.Simulation do
   @impl true
   def init(opts) do
     repository = Keyword.fetch!(opts, :repository)
-    {:ok, repository_runtime} = repository.start_link()
+    {:ok, repository_pid} = repository.start_link()
+    repository_runtime = repository.runtime(repository_pid)
     {:ok, %{repository_runtime: repository_runtime, repository: repository}}
   end
 

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulation.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulation.ex
@@ -8,6 +8,7 @@ defmodule KanbanVisionApi.Usecase.Simulation do
 
   use GenServer
 
+  alias KanbanVisionApi.Usecase.RepositoryConfig
   alias KanbanVisionApi.Usecase.Simulation.CreateSimulationCommand
   alias KanbanVisionApi.Usecase.Simulation.DeleteSimulationCommand
   alias KanbanVisionApi.Usecase.Simulation.GetSimulationByOrgAndNameQuery
@@ -15,7 +16,6 @@ defmodule KanbanVisionApi.Usecase.Simulation do
   alias KanbanVisionApi.Usecase.Simulations.DeleteSimulation
   alias KanbanVisionApi.Usecase.Simulations.GetAllSimulations
   alias KanbanVisionApi.Usecase.Simulations.GetSimulationByOrgAndName
-  alias KanbanVisionApi.Usecase.RepositoryConfig
 
   # Client API
 
@@ -43,32 +43,32 @@ defmodule KanbanVisionApi.Usecase.Simulation do
   @impl true
   def init(opts) do
     repository = Keyword.fetch!(opts, :repository)
-    {:ok, agent_pid} = repository.start_link()
-    {:ok, %{repository_pid: agent_pid, repository: repository}}
+    {:ok, repository_runtime} = repository.start_link()
+    {:ok, %{repository_runtime: repository_runtime, repository: repository}}
   end
 
   @impl true
   def handle_call({:get_all, opts}, _from, state) do
-    result = GetAllSimulations.execute(state.repository_pid, enrich_opts(opts, state))
+    result = GetAllSimulations.execute(state.repository_runtime, enrich_opts(opts, state))
     {:reply, result, state}
   end
 
   @impl true
   def handle_call({:add, cmd, opts}, _from, state) do
-    result = CreateSimulation.execute(cmd, state.repository_pid, enrich_opts(opts, state))
+    result = CreateSimulation.execute(cmd, state.repository_runtime, enrich_opts(opts, state))
     {:reply, result, state}
   end
 
   @impl true
   def handle_call({:delete, cmd, opts}, _from, state) do
-    result = DeleteSimulation.execute(cmd, state.repository_pid, enrich_opts(opts, state))
+    result = DeleteSimulation.execute(cmd, state.repository_runtime, enrich_opts(opts, state))
     {:reply, result, state}
   end
 
   @impl true
   def handle_call({:get_by_org_and_name, query, opts}, _from, state) do
     result =
-      GetSimulationByOrgAndName.execute(query, state.repository_pid, enrich_opts(opts, state))
+      GetSimulationByOrgAndName.execute(query, state.repository_runtime, enrich_opts(opts, state))
 
     {:reply, result, state}
   end

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulations/create_simulation.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulations/create_simulation.ex
@@ -8,6 +8,7 @@ defmodule KanbanVisionApi.Usecase.Simulations.CreateSimulation do
 
   require Logger
 
+  alias KanbanVisionApi.Domain.Ports.SimulationRepository
   alias KanbanVisionApi.Domain.Simulation
   alias KanbanVisionApi.Usecase.EventEmitter
   alias KanbanVisionApi.Usecase.RepositoryConfig
@@ -15,7 +16,8 @@ defmodule KanbanVisionApi.Usecase.Simulations.CreateSimulation do
 
   @type result :: {:ok, Simulation.t()} | {:error, String.t()}
 
-  @spec execute(CreateSimulationCommand.t(), term(), keyword()) :: result()
+  @spec execute(CreateSimulationCommand.t(), SimulationRepository.repository_runtime(), keyword()) ::
+          result()
   def execute(%CreateSimulationCommand{} = cmd, repository_runtime, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
     repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulations/create_simulation.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulations/create_simulation.ex
@@ -15,8 +15,8 @@ defmodule KanbanVisionApi.Usecase.Simulations.CreateSimulation do
 
   @type result :: {:ok, Simulation.t()} | {:error, String.t()}
 
-  @spec execute(CreateSimulationCommand.t(), pid(), keyword()) :: result()
-  def execute(%CreateSimulationCommand{} = cmd, repository_pid, opts \\ []) do
+  @spec execute(CreateSimulationCommand.t(), term(), keyword()) :: result()
+  def execute(%CreateSimulationCommand{} = cmd, repository_runtime, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
     repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
 
@@ -28,7 +28,7 @@ defmodule KanbanVisionApi.Usecase.Simulations.CreateSimulation do
 
     simulation = Simulation.new(cmd.name, cmd.description, cmd.organization_id)
 
-    case repository.add(repository_pid, simulation) do
+    case repository.add(repository_runtime, simulation) do
       {:ok, sim} ->
         Logger.info("Simulation created successfully",
           correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulations/delete_simulation.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulations/delete_simulation.ex
@@ -15,8 +15,8 @@ defmodule KanbanVisionApi.Usecase.Simulations.DeleteSimulation do
 
   @type result :: {:ok, Simulation.t()} | {:error, String.t()}
 
-  @spec execute(DeleteSimulationCommand.t(), pid(), keyword()) :: result()
-  def execute(%DeleteSimulationCommand{} = cmd, repository_pid, opts \\ []) do
+  @spec execute(DeleteSimulationCommand.t(), term(), keyword()) :: result()
+  def execute(%DeleteSimulationCommand{} = cmd, repository_runtime, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
     repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
 
@@ -25,7 +25,7 @@ defmodule KanbanVisionApi.Usecase.Simulations.DeleteSimulation do
       simulation_id: cmd.id
     )
 
-    case repository.delete(repository_pid, cmd.id) do
+    case repository.delete(repository_runtime, cmd.id) do
       {:ok, sim} ->
         Logger.info("Simulation deleted successfully",
           correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulations/delete_simulation.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulations/delete_simulation.ex
@@ -8,6 +8,7 @@ defmodule KanbanVisionApi.Usecase.Simulations.DeleteSimulation do
 
   require Logger
 
+  alias KanbanVisionApi.Domain.Ports.SimulationRepository
   alias KanbanVisionApi.Domain.Simulation
   alias KanbanVisionApi.Usecase.EventEmitter
   alias KanbanVisionApi.Usecase.RepositoryConfig
@@ -15,7 +16,8 @@ defmodule KanbanVisionApi.Usecase.Simulations.DeleteSimulation do
 
   @type result :: {:ok, Simulation.t()} | {:error, String.t()}
 
-  @spec execute(DeleteSimulationCommand.t(), term(), keyword()) :: result()
+  @spec execute(DeleteSimulationCommand.t(), SimulationRepository.repository_runtime(), keyword()) ::
+          result()
   def execute(%DeleteSimulationCommand{} = cmd, repository_runtime, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
     repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulations/get_all_simulations.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulations/get_all_simulations.ex
@@ -7,12 +7,13 @@ defmodule KanbanVisionApi.Usecase.Simulations.GetAllSimulations do
 
   require Logger
 
+  alias KanbanVisionApi.Domain.Ports.SimulationRepository
   alias KanbanVisionApi.Usecase.EventEmitter
   alias KanbanVisionApi.Usecase.RepositoryConfig
 
   @type result :: {:ok, map()}
 
-  @spec execute(term(), keyword()) :: result()
+  @spec execute(SimulationRepository.repository_runtime(), keyword()) :: result()
   def execute(repository_runtime, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
     repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulations/get_all_simulations.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulations/get_all_simulations.ex
@@ -12,14 +12,14 @@ defmodule KanbanVisionApi.Usecase.Simulations.GetAllSimulations do
 
   @type result :: {:ok, map()}
 
-  @spec execute(pid(), keyword()) :: result()
-  def execute(repository_pid, opts \\ []) do
+  @spec execute(term(), keyword()) :: result()
+  def execute(repository_runtime, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
     repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
 
     Logger.debug("Retrieving all simulations", correlation_id: correlation_id)
 
-    simulations = repository.get_all(repository_pid)
+    simulations = repository.get_all(repository_runtime)
 
     Logger.debug("All simulations retrieved",
       correlation_id: correlation_id,

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulations/get_simulation_by_org_and_name.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulations/get_simulation_by_org_and_name.ex
@@ -7,13 +7,18 @@ defmodule KanbanVisionApi.Usecase.Simulations.GetSimulationByOrgAndName do
 
   require Logger
 
+  alias KanbanVisionApi.Domain.Ports.SimulationRepository
   alias KanbanVisionApi.Usecase.RepositoryConfig
   alias KanbanVisionApi.Usecase.Simulation.GetSimulationByOrgAndNameQuery
 
   @type result ::
           {:ok, KanbanVisionApi.Domain.Simulation.t()} | {:error, String.t()}
 
-  @spec execute(GetSimulationByOrgAndNameQuery.t(), term(), keyword()) :: result()
+  @spec execute(
+          GetSimulationByOrgAndNameQuery.t(),
+          SimulationRepository.repository_runtime(),
+          keyword()
+        ) :: result()
   def execute(%GetSimulationByOrgAndNameQuery{} = query, repository_runtime, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
     repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulations/get_simulation_by_org_and_name.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulations/get_simulation_by_org_and_name.ex
@@ -13,8 +13,8 @@ defmodule KanbanVisionApi.Usecase.Simulations.GetSimulationByOrgAndName do
   @type result ::
           {:ok, KanbanVisionApi.Domain.Simulation.t()} | {:error, String.t()}
 
-  @spec execute(GetSimulationByOrgAndNameQuery.t(), pid(), keyword()) :: result()
-  def execute(%GetSimulationByOrgAndNameQuery{} = query, repository_pid, opts \\ []) do
+  @spec execute(GetSimulationByOrgAndNameQuery.t(), term(), keyword()) :: result()
+  def execute(%GetSimulationByOrgAndNameQuery{} = query, repository_runtime, opts \\ []) do
     correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
     repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
 
@@ -26,7 +26,7 @@ defmodule KanbanVisionApi.Usecase.Simulations.GetSimulationByOrgAndName do
 
     result =
       repository.get_by_organization_id_and_simulation_name(
-        repository_pid,
+        repository_runtime,
         query.organization_id,
         query.name
       )

--- a/apps/web_api/lib/kanban_vision_api/web_api/router.ex
+++ b/apps/web_api/lib/kanban_vision_api/web_api/router.ex
@@ -13,10 +13,13 @@ defmodule KanbanVisionApi.WebApi.Router do
   alias KanbanVisionApi.WebApi.Plugs.CorrelationId
   alias KanbanVisionApi.WebApi.Plugs.RequestLogger
   alias KanbanVisionApi.WebApi.Simulations.SimulationController
+  alias OpenApiSpex.Plug.PutApiSpec
+  alias OpenApiSpex.Plug.RenderSpec
+  alias OpenApiSpex.Plug.SwaggerUI
 
   plug CorrelationId
   plug RequestLogger
-  plug OpenApiSpex.Plug.PutApiSpec, module: Spec
+  plug PutApiSpec, module: Spec
 
   plug Plug.Parsers,
     parsers: [:json],
@@ -30,13 +33,13 @@ defmodule KanbanVisionApi.WebApi.Router do
   # OpenAPI documentation routes
 
   get "/api/openapi" do
-    opts = OpenApiSpex.Plug.RenderSpec.init([])
-    OpenApiSpex.Plug.RenderSpec.call(conn, opts)
+    opts = RenderSpec.init([])
+    RenderSpec.call(conn, opts)
   end
 
   get "/api/swagger" do
-    opts = OpenApiSpex.Plug.SwaggerUI.init(path: "/api/openapi")
-    OpenApiSpex.Plug.SwaggerUI.call(conn, opts)
+    opts = SwaggerUI.init(path: "/api/openapi")
+    SwaggerUI.call(conn, opts)
   end
 
   # Organization routes — /search before /:id

--- a/apps/web_api/test/kanban_vision_api/web_api/organizations/organization_controller_test.exs
+++ b/apps/web_api/test/kanban_vision_api/web_api/organizations/organization_controller_test.exs
@@ -6,8 +6,8 @@ defmodule KanbanVisionApi.WebApi.Organizations.OrganizationControllerTest do
   import Plug.Test
 
   alias KanbanVisionApi.Domain.Organization
-  alias KanbanVisionApi.WebApi.OrganizationUsecaseMock
   alias KanbanVisionApi.WebApi.Organizations.OrganizationController
+  alias KanbanVisionApi.WebApi.OrganizationUsecaseMock
 
   setup :verify_on_exit!
 

--- a/apps/web_api/test/kanban_vision_api/web_api/simulations/simulation_controller_test.exs
+++ b/apps/web_api/test/kanban_vision_api/web_api/simulations/simulation_controller_test.exs
@@ -5,8 +5,8 @@ defmodule KanbanVisionApi.WebApi.Simulations.SimulationControllerTest do
   import Plug.Test
 
   alias KanbanVisionApi.Domain.Simulation
-  alias KanbanVisionApi.WebApi.SimulationUsecaseMock
   alias KanbanVisionApi.WebApi.Simulations.SimulationController
+  alias KanbanVisionApi.WebApi.SimulationUsecaseMock
 
   setup :verify_on_exit!
 


### PR DESCRIPTION
## Summary
- remove raw pid leakage from domain repository ports
- encapsulate Agent processes behind opaque repository runtimes in persistence adapters
- update usecase orchestration, tests, ADR 0002, and repository guidance to the new boundary

## Validation
- mix format
- mix compile
- mix test
- mix credo --strict
- mix dialyzer