### PR TITLE
refactor: adopt structured application errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Keep business logic in use cases and domain modules. Controllers, routers, jobs,
 - Repository mutations must use `Agent.get_and_update/3` for atomicity.
 - Agent access stays internal to persistence adapters; do not expose raw `pid` in domain ports or introduce atom registration.
 - GenServers orchestrate and delegate. They do not own business rules.
+- Application-visible failures must use structured errors; adapters must not infer behavior by parsing error message text.
 - New business flows must include structured logging and telemetry.
 
 ## Build, Test, and Verification

--- a/adr/0003-adopt-structured-application-errors.md
+++ b/adr/0003-adopt-structured-application-errors.md
@@ -1,0 +1,201 @@
+# 0003. Adopt Structured Application Errors Across Persistence, Usecase, and HTTP
+
+- Status: accepted
+- Date: 2026-03-27
+- Supersedes: none
+- Related:
+  - 0001-use-cqs-and-hexagonal-boundaries-with-in-memory-persistence
+  - 0002-remove-pid-leakage-from-domain-repository-ports
+
+## Context
+
+ADR 0001 established that the project should keep:
+
+- CQS at the application boundary
+- inward dependency direction
+- in-memory persistence during process execution
+- use-case-first orchestration with HTTP adapters limited to translation
+
+ADR 0002 removed raw `pid` leakage from domain repository ports and pushed
+runtime process details behind opaque repository runtimes. That improved the
+boundary between domain, usecase, and persistence, but one important coupling
+still remains: failures are still propagated as free-form strings and interpreted
+differently by outer layers.
+
+Today, the codebase still contains these patterns:
+
+- `persistence` adapters return string errors such as `"not found"` and
+  `"already exist"`
+- `usecase` modules propagate those strings upward as application failures
+- `web_api` controllers determine HTTP status codes by parsing message text with
+  `String.contains?/2`
+
+This keeps the transport layer coupled to incidental wording from persistence
+adapters. As a result:
+
+- HTTP behavior depends on text phrasing instead of semantic categories
+- changing an error message can unintentionally change API behavior
+- tests remain brittle because they assert wording instead of intent
+- future persistence evolution, including prevalence-oriented persistence, would
+  still be forced to preserve incidental message conventions
+
+The project does not plan to adopt CQRS at this stage. This ADR remains aligned
+with CQS and does not change the in-memory runtime model. The decision is only
+about replacing string-based failure contracts with structured application
+errors.
+
+## Decision
+
+We will adopt structured application errors across `persistence`, `usecase`, and
+`web_api`.
+
+The canonical application-facing failure shape will be:
+
+- `{:error, %{code: atom(), message: String.t(), details: map()}}`
+
+The intent of each field is:
+
+- `code`: stable semantic category used by application and transport logic
+- `message`: human-readable description
+- `details`: optional contextual data for debugging, logging, or downstream
+  handling
+
+The following canonical error codes are adopted initially:
+
+- `:invalid_input`
+- `:not_found`
+- `:conflict`
+- `:internal_error`
+
+HTTP adapters must map status codes from `code`, never from `message`.
+
+The initial HTTP status mapping will be:
+
+- `:invalid_input -> 422`
+- `:not_found -> 404`
+- `:conflict -> 409`
+- `:internal_error -> 500`
+
+Validation failures produced at command/query construction time may continue to
+originate as explicit atoms during the transition, but before an error crosses
+the HTTP boundary it must be normalized to the structured application error
+contract.
+
+Persistence adapters may still generate descriptive messages, but those messages
+must travel together with explicit error codes rather than acting as the only
+contract.
+
+This ADR does not change the current public JSON error body shape. For now, HTTP
+responses may continue to render:
+
+- `%{error: message}`
+
+This ADR also does not introduce:
+
+- exception-based control flow
+- internationalization of errors
+- public API versioning changes
+- a global error catalog beyond the initial canonical codes
+
+## Considered Options
+
+### Option A
+
+Keep propagating string errors and continue mapping HTTP status by parsing error
+messages.
+
+Why it was not chosen:
+
+- couples transport behavior to persistence wording
+- keeps the boundary fragile and hard to evolve
+- makes tests brittle and semantically weak
+
+### Option B
+
+Adopt structured application errors and map HTTP behavior from explicit error
+codes.
+
+Why it is preferred:
+
+- creates a stable boundary across adapters and use cases
+- keeps HTTP translation independent of wording changes
+- aligns with the intended hexagonal architecture
+- makes future persistence changes safer
+
+## Consequences
+
+### Positive
+
+- HTTP adapters become deterministic and independent of error message wording.
+- Persistence and use case layers gain a stable failure contract.
+- Tests can assert semantic categories instead of brittle text fragments.
+- Future persistence evolution remains compatible with the current architecture.
+- Logging and telemetry can use structured failure categories directly.
+
+### Negative
+
+- The refactor will touch `persistence`, `usecase`, `web_api`, and tests.
+- Transitional coexistence with legacy validation atoms must be managed.
+- Existing tests and documentation that assume string-based failures will need
+  updates.
+
+## Execution Plan
+
+### Phase 1: Error Contract Definition
+
+- Introduce a shared application error contract and canonical error categories.
+- Define normalization rules for validation atoms and structured adapter errors.
+- Document the HTTP mapping rules from error code to response status.
+
+Status:
+- Completed.
+
+### Phase 2: Persistence And Usecase Adoption
+
+- Update Agent adapters to return structured errors instead of raw string-only
+  tuples.
+- Update use cases to propagate structured errors as the application contract.
+- Preserve structured logging while including `code` and relevant `details`.
+
+Status:
+- Completed.
+
+### Phase 3: HTTP Mapping Refactor
+
+- Replace `String.contains?/2`-based error mapping in controllers with explicit
+  `code` mapping.
+- Keep response body shape as `%{error: message}` unless a later ADR changes the
+  public error payload.
+
+Status:
+- Completed.
+
+### Phase 4: Test And Contract Alignment
+
+- Update persistence contract tests to assert semantic error codes.
+- Update use case tests to assert structured error propagation.
+- Update controller tests to assert status mapping by category instead of
+  message parsing.
+- Remove brittle assertions that rely on incidental wording when wording is not
+  the contract.
+
+Status:
+- Completed.
+
+## Acceptance Criteria For Future Implementation
+
+- No controller uses `String.contains?/2` or equivalent message parsing to map
+  HTTP status.
+- Persistence adapters return structured errors for conflict and missing-resource
+  scenarios.
+- Use cases propagate structured application errors consistently.
+- HTTP adapters map `:invalid_input`, `:not_found`, `:conflict`, and
+  `:internal_error` deterministically.
+- The current public JSON error body shape remains backward compatible unless a
+  later ADR changes it.
+
+## Notes
+
+This ADR records the next architectural refactoring phase after ADR 0002. It
+preserves the current CQS model and in-memory runtime while strengthening the
+failure contract across architectural boundaries.

--- a/adr/README.md
+++ b/adr/README.md
@@ -13,3 +13,4 @@ This directory stores the project's Architectural Decision Records (ADRs).
 
 - [0001-use-cqs-and-hexagonal-boundaries-with-in-memory-persistence](0001-use-cqs-and-hexagonal-boundaries-with-in-memory-persistence.md)
 - [0002-remove-pid-leakage-from-domain-repository-ports](0002-remove-pid-leakage-from-domain-repository-ports.md)
+- [0003-adopt-structured-application-errors](0003-adopt-structured-application-errors.md)

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/ports/application_error.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/ports/application_error.ex
@@ -19,7 +19,8 @@ defmodule KanbanVisionApi.Domain.Ports.ApplicationError do
 
   @spec new(code(), String.t(), map()) :: t()
   def new(code, message, details \\ %{})
-      when is_atom(code) and is_binary(message) and is_map(details) do
+      when code in [:invalid_input, :not_found, :conflict, :internal_error] and
+             is_binary(message) and is_map(details) do
     %__MODULE__{code: code, message: message, details: details}
   end
 

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/ports/application_error.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/ports/application_error.ex
@@ -1,0 +1,42 @@
+defmodule KanbanVisionApi.Domain.Ports.ApplicationError do
+  @moduledoc """
+  Structured error contract shared across persistence, use cases, and adapters.
+  """
+
+  @enforce_keys [:code, :message, :details]
+  defstruct [:code, :message, :details]
+
+  @type code :: :invalid_input | :not_found | :conflict | :internal_error
+
+  @type t :: %__MODULE__{
+          code: code(),
+          message: String.t(),
+          details: map()
+        }
+
+  @type error_result :: {:error, t()}
+  @type result(value) :: {:ok, value} | error_result()
+
+  @spec new(code(), String.t(), map()) :: t()
+  def new(code, message, details \\ %{})
+      when is_atom(code) and is_binary(message) and is_map(details) do
+    %__MODULE__{code: code, message: message, details: details}
+  end
+
+  @spec error(code(), String.t(), map()) :: error_result()
+  def error(code, message, details \\ %{}) do
+    {:error, new(code, message, details)}
+  end
+
+  @spec invalid_input(String.t(), map()) :: error_result()
+  def invalid_input(message, details \\ %{}), do: error(:invalid_input, message, details)
+
+  @spec not_found(String.t(), map()) :: error_result()
+  def not_found(message, details \\ %{}), do: error(:not_found, message, details)
+
+  @spec conflict(String.t(), map()) :: error_result()
+  def conflict(message, details \\ %{}), do: error(:conflict, message, details)
+
+  @spec internal_error(String.t(), map()) :: error_result()
+  def internal_error(message, details \\ %{}), do: error(:internal_error, message, details)
+end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/ports/board_repository.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/ports/board_repository.ex
@@ -4,17 +4,18 @@ defmodule KanbanVisionApi.Domain.Ports.BoardRepository do
   """
 
   alias KanbanVisionApi.Domain.Board
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
   alias KanbanVisionApi.Domain.Ports.RepositoryRuntime
 
   @type repository_runtime :: RepositoryRuntime.t()
 
   @callback get_all(runtime :: repository_runtime()) :: map()
   @callback get_by_id(runtime :: repository_runtime(), id :: String.t()) ::
-              {:ok, Board.t()} | {:error, String.t()}
+              ApplicationError.result(Board.t())
   @callback add(runtime :: repository_runtime(), board :: Board.t()) ::
-              {:ok, Board.t()} | {:error, String.t()}
+              ApplicationError.result(Board.t())
   @callback delete(runtime :: repository_runtime(), id :: String.t()) ::
-              {:ok, Board.t()} | {:error, String.t()}
+              ApplicationError.result(Board.t())
   @callback get_all_by_simulation_id(runtime :: repository_runtime(), simulation_id :: String.t()) ::
-              {:ok, [Board.t()]} | {:error, String.t()}
+              ApplicationError.result([Board.t()])
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/ports/organization_repository.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/ports/organization_repository.ex
@@ -4,17 +4,18 @@ defmodule KanbanVisionApi.Domain.Ports.OrganizationRepository do
   """
 
   alias KanbanVisionApi.Domain.Organization
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
   alias KanbanVisionApi.Domain.Ports.RepositoryRuntime
 
   @type repository_runtime :: RepositoryRuntime.t()
 
   @callback get_all(runtime :: repository_runtime()) :: map()
   @callback get_by_id(runtime :: repository_runtime(), id :: String.t()) ::
-              {:ok, Organization.t()} | {:error, String.t()}
+              ApplicationError.result(Organization.t())
   @callback get_by_name(runtime :: repository_runtime(), name :: String.t()) ::
-              {:ok, [Organization.t()]} | {:error, String.t()}
+              ApplicationError.result([Organization.t()])
   @callback add(runtime :: repository_runtime(), organization :: Organization.t()) ::
-              {:ok, Organization.t()} | {:error, String.t()}
+              ApplicationError.result(Organization.t())
   @callback delete(runtime :: repository_runtime(), id :: String.t()) ::
-              {:ok, Organization.t()} | {:error, String.t()}
+              ApplicationError.result(Organization.t())
 end

--- a/apps/kanban_domain/lib/kanban_vision_api/domain/ports/simulation_repository.ex
+++ b/apps/kanban_domain/lib/kanban_vision_api/domain/ports/simulation_repository.ex
@@ -3,6 +3,7 @@ defmodule KanbanVisionApi.Domain.Ports.SimulationRepository do
   Port defining the contract for simulation persistence.
   """
 
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
   alias KanbanVisionApi.Domain.Ports.RepositoryRuntime
   alias KanbanVisionApi.Domain.Simulation
 
@@ -10,12 +11,12 @@ defmodule KanbanVisionApi.Domain.Ports.SimulationRepository do
 
   @callback get_all(runtime :: repository_runtime()) :: map()
   @callback add(runtime :: repository_runtime(), simulation :: Simulation.t()) ::
-              {:ok, Simulation.t()} | {:error, String.t()}
+              ApplicationError.result(Simulation.t())
   @callback delete(runtime :: repository_runtime(), id :: String.t()) ::
-              {:ok, Simulation.t()} | {:error, String.t()}
+              ApplicationError.result(Simulation.t())
   @callback get_by_organization_id_and_simulation_name(
               runtime :: repository_runtime(),
               org_id :: String.t(),
               name :: String.t()
-            ) :: {:ok, Simulation.t()} | {:error, String.t()}
+            ) :: ApplicationError.result(Simulation.t())
 end

--- a/apps/persistence/lib/kanban_vision_api/agent/boards.ex
+++ b/apps/persistence/lib/kanban_vision_api/agent/boards.ex
@@ -5,6 +5,9 @@ defmodule KanbanVisionApi.Agent.Boards do
 
   @behaviour KanbanVisionApi.Domain.Ports.BoardRepository
 
+  alias KanbanVisionApi.Domain.Board
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
+
   defmodule Runtime do
     @moduledoc false
 
@@ -38,7 +41,7 @@ defmodule KanbanVisionApi.Agent.Boards do
   @spec runtime(pid()) :: runtime()
   def runtime(pid), do: %Runtime{pid: pid}
 
-  def add(%Runtime{pid: pid}, %KanbanVisionApi.Domain.Board{} = new_board) do
+  def add(%Runtime{pid: pid}, %Board{} = new_board) do
     Agent.get_and_update(pid, fn state ->
       case get_by_board(state.boards, new_board) do
         {:error, _} ->
@@ -51,11 +54,7 @@ defmodule KanbanVisionApi.Agent.Boards do
           {{:ok, new_board}, new_state}
 
         {:ok, _} ->
-          {{:error,
-            """
-            Board with name: #{new_board.name}
-            from simulation_id: #{new_board.simulation_id} already exist
-            """}, state}
+          {conflict_by_name_and_simulation_id(new_board.name, new_board.simulation_id), state}
       end
     end)
   end
@@ -63,7 +62,7 @@ defmodule KanbanVisionApi.Agent.Boards do
   def get_by_id(%Runtime{pid: pid}, board_id) do
     Agent.get(pid, fn state ->
       case Map.get(state.boards, board_id) do
-        nil -> {:error, "Board with id: #{board_id} not found"}
+        nil -> not_found_by_id(board_id)
         board -> {:ok, board}
       end
     end)
@@ -77,7 +76,7 @@ defmodule KanbanVisionApi.Agent.Boards do
     Agent.get_and_update(pid, fn state ->
       case Map.get(state.boards, board_id) do
         nil ->
-          {{:error, "Board with id: #{board_id} not found"}, state}
+          {not_found_by_id(board_id), state}
 
         board ->
           new_state = put_in(state.boards, Map.delete(state.boards, board_id))
@@ -100,7 +99,7 @@ defmodule KanbanVisionApi.Agent.Boards do
 
   defp prepare_by_boards_result(result_list, simulation_id) do
     case result_list do
-      [] -> {:error, "Boards by simulation_id: #{simulation_id} not found"}
+      [] -> not_found_by_simulation_id(simulation_id)
       _ -> {:ok, result_list}
     end
   end
@@ -117,12 +116,40 @@ defmodule KanbanVisionApi.Agent.Boards do
         boards_by_name = Enum.filter(filtered_boards, fn board -> board.name == name end)
 
         case boards_by_name do
-          [] -> {:error, "Boards by name: #{name} and simulation_id: #{simulation_id} not found"}
+          [] -> not_found_by_name_and_simulation_id(name, simulation_id)
           _ -> {:ok, boards_by_name}
         end
 
       _ ->
         result
     end
+  end
+
+  defp not_found_by_id(board_id) do
+    ApplicationError.not_found(
+      "Board with id: #{board_id} not found",
+      %{entity: :board, id: board_id}
+    )
+  end
+
+  defp not_found_by_simulation_id(simulation_id) do
+    ApplicationError.not_found(
+      "Boards by simulation_id: #{simulation_id} not found",
+      %{entity: :board, field: :simulation_id, simulation_id: simulation_id}
+    )
+  end
+
+  defp not_found_by_name_and_simulation_id(name, simulation_id) do
+    ApplicationError.not_found(
+      "Boards by name: #{name} and simulation_id: #{simulation_id} not found",
+      %{entity: :board, field: :name, name: name, simulation_id: simulation_id}
+    )
+  end
+
+  defp conflict_by_name_and_simulation_id(name, simulation_id) do
+    ApplicationError.conflict(
+      "Board with name: #{name} from simulation_id: #{simulation_id} already exist",
+      %{entity: :board, field: :name, name: name, simulation_id: simulation_id}
+    )
   end
 end

--- a/apps/persistence/lib/kanban_vision_api/agent/organizations.ex
+++ b/apps/persistence/lib/kanban_vision_api/agent/organizations.ex
@@ -5,6 +5,9 @@ defmodule KanbanVisionApi.Agent.Organizations do
 
   @behaviour KanbanVisionApi.Domain.Ports.OrganizationRepository
 
+  alias KanbanVisionApi.Domain.Organization
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
+
   defmodule Runtime do
     @moduledoc false
 
@@ -45,7 +48,7 @@ defmodule KanbanVisionApi.Agent.Organizations do
   def get_by_id(%Runtime{pid: pid}, domain_id) do
     Agent.get(pid, fn state ->
       case Map.get(state.organizations, domain_id) do
-        nil -> {:error, "Organization with id: #{domain_id} not found"}
+        nil -> not_found_by_id(domain_id)
         domain -> {:ok, domain}
       end
     end)
@@ -57,7 +60,7 @@ defmodule KanbanVisionApi.Agent.Organizations do
     end)
   end
 
-  def add(%Runtime{pid: pid}, %KanbanVisionApi.Domain.Organization{} = new_organization) do
+  def add(%Runtime{pid: pid}, %Organization{} = new_organization) do
     Agent.get_and_update(pid, fn state ->
       case internal_get_by_name(state.organizations, new_organization.name) do
         {:error, _} ->
@@ -66,7 +69,7 @@ defmodule KanbanVisionApi.Agent.Organizations do
           {{:ok, new_organization}, new_state}
 
         {:ok, _} ->
-          {{:error, "Organization with name: #{new_organization.name} already exist"}, state}
+          {conflict_by_name(new_organization.name), state}
       end
     end)
   end
@@ -75,7 +78,7 @@ defmodule KanbanVisionApi.Agent.Organizations do
     Agent.get_and_update(pid, fn state ->
       case Map.get(state.organizations, domain_id) do
         nil ->
-          {{:error, "Organization with id: #{domain_id} not found"}, state}
+          {not_found_by_id(domain_id), state}
 
         domain ->
           new_orgs = Map.delete(state.organizations, domain.id)
@@ -93,8 +96,29 @@ defmodule KanbanVisionApi.Agent.Organizations do
 
   defp prepare_by_name_result(result_list, domain_name) do
     case result_list do
-      values when values == [] -> {:error, "Organization with name: #{domain_name} not found"}
+      values when values == [] -> not_found_by_name(domain_name)
       values -> {:ok, values}
     end
+  end
+
+  defp not_found_by_id(domain_id) do
+    ApplicationError.not_found(
+      "Organization with id: #{domain_id} not found",
+      %{entity: :organization, id: domain_id}
+    )
+  end
+
+  defp not_found_by_name(domain_name) do
+    ApplicationError.not_found(
+      "Organization with name: #{domain_name} not found",
+      %{entity: :organization, field: :name, name: domain_name}
+    )
+  end
+
+  defp conflict_by_name(domain_name) do
+    ApplicationError.conflict(
+      "Organization with name: #{domain_name} already exist",
+      %{entity: :organization, field: :name, name: domain_name}
+    )
   end
 end

--- a/apps/persistence/lib/kanban_vision_api/agent/simulations.ex
+++ b/apps/persistence/lib/kanban_vision_api/agent/simulations.ex
@@ -5,6 +5,9 @@ defmodule KanbanVisionApi.Agent.Simulations do
 
   @behaviour KanbanVisionApi.Domain.Ports.SimulationRepository
 
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
+  alias KanbanVisionApi.Domain.Simulation
+
   defmodule Runtime do
     @moduledoc false
 
@@ -42,7 +45,7 @@ defmodule KanbanVisionApi.Agent.Simulations do
     Agent.get(pid, fn state -> state.simulations_by_organization end)
   end
 
-  def add(%Runtime{pid: pid}, %KanbanVisionApi.Domain.Simulation{} = new_simulation) do
+  def add(%Runtime{pid: pid}, %Simulation{} = new_simulation) do
     Agent.get_and_update(pid, fn state ->
       result =
         internal_find_by_org_and_name(
@@ -80,11 +83,7 @@ defmodule KanbanVisionApi.Agent.Simulations do
           {{:ok, new_simulation}, new_state}
 
         {:ok, _} ->
-          {{:error,
-            """
-            Simulation with organization_id: #{new_simulation.organization_id}
-            name: #{new_simulation.name} already exist
-            """}, state}
+          {conflict_by_org_and_name(new_simulation.organization_id, new_simulation.name), state}
       end
     end)
   end
@@ -134,7 +133,7 @@ defmodule KanbanVisionApi.Agent.Simulations do
       |> Enum.find(fn sim -> sim.id == simulation_id end)
 
     case result do
-      nil -> {:error, "Simulation with id: #{simulation_id} not found"}
+      nil -> not_found_by_id(simulation_id)
       simulation -> {:ok, simulation}
     end
   end
@@ -142,7 +141,7 @@ defmodule KanbanVisionApi.Agent.Simulations do
   defp internal_find_by_org_and_name(state, organization_id, simulation_name) do
     case Map.get(state.simulations_by_organization, organization_id) do
       nil ->
-        {:error, "Simulation with organization id: #{organization_id} not found"}
+        not_found_by_organization_id(organization_id)
 
       map_of_simulations ->
         find_by_simulation_name(map_of_simulations, organization_id, simulation_name)
@@ -151,7 +150,7 @@ defmodule KanbanVisionApi.Agent.Simulations do
 
   defp find_by_simulation_name(map_of_simulations, organization_id, simulation_name) do
     case Map.values(map_of_simulations) do
-      [] -> {:error, "Simulation with organization id: #{organization_id} not found"}
+      [] -> not_found_by_organization_id(organization_id)
       list_of_simulations -> find_by_simulation_name(list_of_simulations, simulation_name)
     end
   end
@@ -161,8 +160,41 @@ defmodule KanbanVisionApi.Agent.Simulations do
            list_of_simulations,
            fn simulation -> simulation.name == simulation_name end
          ) do
-      nil -> {:error, "Simulation with name: #{simulation_name} not found"}
+      nil -> not_found_by_name(simulation_name)
       simulation -> {:ok, simulation}
     end
+  end
+
+  defp not_found_by_id(simulation_id) do
+    ApplicationError.not_found(
+      "Simulation with id: #{simulation_id} not found",
+      %{entity: :simulation, id: simulation_id}
+    )
+  end
+
+  defp not_found_by_organization_id(organization_id) do
+    ApplicationError.not_found(
+      "Simulation with organization id: #{organization_id} not found",
+      %{entity: :simulation, field: :organization_id, organization_id: organization_id}
+    )
+  end
+
+  defp not_found_by_name(simulation_name) do
+    ApplicationError.not_found(
+      "Simulation with name: #{simulation_name} not found",
+      %{entity: :simulation, field: :name, name: simulation_name}
+    )
+  end
+
+  defp conflict_by_org_and_name(organization_id, simulation_name) do
+    ApplicationError.conflict(
+      "Simulation with organization_id: #{organization_id} name: #{simulation_name} already exist",
+      %{
+        entity: :simulation,
+        field: :name,
+        name: simulation_name,
+        organization_id: organization_id
+      }
+    )
   end
 end

--- a/apps/persistence/test/kanban_vision_api/agent/boards_test.exs
+++ b/apps/persistence/test/kanban_vision_api/agent/boards_test.exs
@@ -4,6 +4,7 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
 
   alias KanbanVisionApi.Agent.Boards
   alias KanbanVisionApi.Domain.Board
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
   alias KanbanVisionApi.Domain.Workflow
 
   describe "When start the system with empty state" do
@@ -25,8 +26,11 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
            repository_runtime: repository_runtime,
            boards: _boards
          } = _context do
-      template = {:error, "Boards by simulation_id: nada not found"}
-      assert Boards.get_all_by_simulation_id(repository_runtime, "nada") == template
+      assert Boards.get_all_by_simulation_id(repository_runtime, "nada") ==
+               ApplicationError.not_found(
+                 "Boards by simulation_id: nada not found",
+                 %{entity: :board, field: :simulation_id, simulation_id: "nada"}
+               )
     end
 
     @tag :domain_boards
@@ -101,8 +105,11 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
          %{
            repository_runtime: repository_runtime
          } = _context do
-      assert {:error, "Board with id: unknown-id not found"} =
-               Boards.get_by_id(repository_runtime, "unknown-id")
+      assert Boards.get_by_id(repository_runtime, "unknown-id") ==
+               ApplicationError.not_found(
+                 "Board with id: unknown-id not found",
+                 %{entity: :board, id: "unknown-id"}
+               )
     end
 
     @tag :domain_boards
@@ -120,8 +127,11 @@ defmodule KanbanVisionApi.Agent.BoardsTest do
          %{
            repository_runtime: repository_runtime
          } = _context do
-      assert {:error, "Board with id: unknown-id not found"} =
-               Boards.delete(repository_runtime, "unknown-id")
+      assert Boards.delete(repository_runtime, "unknown-id") ==
+               ApplicationError.not_found(
+                 "Board with id: unknown-id not found",
+                 %{entity: :board, id: "unknown-id"}
+               )
     end
   end
 

--- a/apps/persistence/test/kanban_vision_api/agent/organizations_test.exs
+++ b/apps/persistence/test/kanban_vision_api/agent/organizations_test.exs
@@ -4,6 +4,7 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
 
   alias KanbanVisionApi.Agent.Organizations
   alias KanbanVisionApi.Domain.Organization
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
 
   describe "When start the system with empty state" do
     setup [:prepare_empty_context]
@@ -45,8 +46,11 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
            repository_runtime: repository_runtime,
            organizations: _organizations
          } = _context do
-      template = {:error, "Organization with id: nada not found"}
-      assert Organizations.delete(repository_runtime, :nada) == template
+      assert Organizations.delete(repository_runtime, :nada) ==
+               ApplicationError.not_found(
+                 "Organization with id: nada not found",
+                 %{entity: :organization, id: :nada}
+               )
     end
   end
 
@@ -92,8 +96,11 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
            organizations: _organizations,
            domain: _domain
          } = _context do
-      template = {:error, "Organization with id: nada not found"}
-      assert Organizations.get_by_id(repository_runtime, :nada) == template
+      assert Organizations.get_by_id(repository_runtime, :nada) ==
+               ApplicationError.not_found(
+                 "Organization with id: nada not found",
+                 %{entity: :organization, id: :nada}
+               )
     end
 
     @tag :domain_organizations
@@ -103,8 +110,11 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
            organizations: _organizations,
            domain: _domain
          } = _context do
-      template = {:error, "Organization with name: Invalid Name not found"}
-      assert Organizations.get_by_name(repository_runtime, "Invalid Name") == template
+      assert Organizations.get_by_name(repository_runtime, "Invalid Name") ==
+               ApplicationError.not_found(
+                 "Organization with name: Invalid Name not found",
+                 %{entity: :organization, field: :name, name: "Invalid Name"}
+               )
     end
 
     @tag :domain_organizations
@@ -114,8 +124,11 @@ defmodule KanbanVisionApi.Agent.OrganizationsTest do
            organizations: _organizations,
            domain: domain
          } = _context do
-      template = {:error, "Organization with name: ExampleOrg already exist"}
-      assert Organizations.add(repository_runtime, domain) == template
+      assert Organizations.add(repository_runtime, domain) ==
+               ApplicationError.conflict(
+                 "Organization with name: ExampleOrg already exist",
+                 %{entity: :organization, field: :name, name: "ExampleOrg"}
+               )
     end
   end
 

--- a/apps/persistence/test/kanban_vision_api/agent/simulations_test.exs
+++ b/apps/persistence/test/kanban_vision_api/agent/simulations_test.exs
@@ -4,6 +4,7 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
 
   alias KanbanVisionApi.Agent.Simulations
   alias KanbanVisionApi.Domain.Organization
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
   alias KanbanVisionApi.Domain.Simulation
 
   describe "When start the system with empty state" do
@@ -90,10 +91,17 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
          } = _context do
       assert Simulations.add(repository_runtime, simulation) == {
                :error,
-               """
-               Simulation with organization_id: #{simulation.organization_id}
-               name: #{simulation.name} already exist
-               """
+               %ApplicationError{
+                 code: :conflict,
+                 message:
+                   "Simulation with organization_id: #{simulation.organization_id} name: #{simulation.name} already exist",
+                 details: %{
+                   entity: :simulation,
+                   field: :name,
+                   name: simulation.name,
+                   organization_id: simulation.organization_id
+                 }
+               }
              }
     end
 
@@ -104,13 +112,15 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
            simulations: _simulations,
            organization: _organization
          } = _context do
-      template = {:error, "Simulation with organization id: INVALID not found"}
-
       assert Simulations.get_by_organization_id_and_simulation_name(
                repository_runtime,
                "INVALID",
                "Simulation Name"
-             ) == template
+             ) ==
+               ApplicationError.not_found(
+                 "Simulation with organization id: INVALID not found",
+                 %{entity: :simulation, field: :organization_id, organization_id: "INVALID"}
+               )
     end
 
     @tag :domain_simulations
@@ -119,13 +129,15 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
            repository_runtime: repository_runtime,
            organization: organization
          } = _context do
-      template = {:error, "Simulation with name: Missing Simulation not found"}
-
       assert Simulations.get_by_organization_id_and_simulation_name(
                repository_runtime,
                organization.id,
                "Missing Simulation"
-             ) == template
+             ) ==
+               ApplicationError.not_found(
+                 "Simulation with name: Missing Simulation not found",
+                 %{entity: :simulation, field: :name, name: "Missing Simulation"}
+               )
     end
 
     @tag :domain_simulations
@@ -143,8 +155,11 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
          %{
            repository_runtime: repository_runtime
          } = _context do
-      assert {:error, "Simulation with id: unknown-id not found"} =
-               Simulations.delete(repository_runtime, "unknown-id")
+      assert Simulations.delete(repository_runtime, "unknown-id") ==
+               ApplicationError.not_found(
+                 "Simulation with id: unknown-id not found",
+                 %{entity: :simulation, id: "unknown-id"}
+               )
     end
 
     @tag :domain_simulations
@@ -175,13 +190,19 @@ defmodule KanbanVisionApi.Agent.SimulationsTest do
            repository_runtime: repository_runtime,
            organization: organization
          } = _context do
-      template = {:error, "Simulation with organization id: #{organization.id} not found"}
-
       assert Simulations.get_by_organization_id_and_simulation_name(
                repository_runtime,
                organization.id,
                "Any Simulation"
-             ) == template
+             ) ==
+               ApplicationError.not_found(
+                 "Simulation with organization id: #{organization.id} not found",
+                 %{
+                   entity: :simulation,
+                   field: :organization_id,
+                   organization_id: organization.id
+                 }
+               )
     end
   end
 

--- a/apps/usecase/lib/kanban_vision_api/usecase/boards/delete_board.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/boards/delete_board.ex
@@ -9,12 +9,14 @@ defmodule KanbanVisionApi.Usecase.Boards.DeleteBoard do
   require Logger
 
   alias KanbanVisionApi.Domain.Board
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
   alias KanbanVisionApi.Domain.Ports.BoardRepository
   alias KanbanVisionApi.Usecase.Board.DeleteBoardCommand
+  alias KanbanVisionApi.Usecase.ErrorMetadata
   alias KanbanVisionApi.Usecase.EventEmitter
   alias KanbanVisionApi.Usecase.RepositoryConfig
 
-  @type result :: {:ok, Board.t()} | {:error, String.t()}
+  @type result :: ApplicationError.result(Board.t())
 
   @spec execute(DeleteBoardCommand.t(), BoardRepository.repository_runtime(), keyword()) ::
           result()
@@ -50,11 +52,11 @@ defmodule KanbanVisionApi.Usecase.Boards.DeleteBoard do
         {:ok, board}
 
       {:error, reason} = error ->
-        Logger.error("Failed to delete board",
-          correlation_id: correlation_id,
-          board_id: cmd.id,
-          reason: reason
-        )
+        metadata =
+          [correlation_id: correlation_id, board_id: cmd.id] ++
+            ErrorMetadata.from_reason(reason)
+
+        Logger.error("Failed to delete board", metadata)
 
         error
     end

--- a/apps/usecase/lib/kanban_vision_api/usecase/error_metadata.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/error_metadata.ex
@@ -1,0 +1,16 @@
+defmodule KanbanVisionApi.Usecase.ErrorMetadata do
+  @moduledoc false
+
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
+
+  @spec from_reason(term()) :: keyword()
+  def from_reason(%ApplicationError{} = error) do
+    [
+      error_code: error.code,
+      error_message: error.message,
+      error_details: error.details
+    ]
+  end
+
+  def from_reason(reason), do: [reason: reason]
+end

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/create_organization.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/create_organization.ex
@@ -9,12 +9,14 @@ defmodule KanbanVisionApi.Usecase.Organizations.CreateOrganization do
   require Logger
 
   alias KanbanVisionApi.Domain.Organization
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
   alias KanbanVisionApi.Domain.Ports.OrganizationRepository
+  alias KanbanVisionApi.Usecase.ErrorMetadata
   alias KanbanVisionApi.Usecase.EventEmitter
   alias KanbanVisionApi.Usecase.Organization.CreateOrganizationCommand
   alias KanbanVisionApi.Usecase.RepositoryConfig
 
-  @type result :: {:ok, Organization.t()} | {:error, String.t()}
+  @type result :: ApplicationError.result(Organization.t())
 
   @spec execute(
           CreateOrganizationCommand.t(),
@@ -55,11 +57,11 @@ defmodule KanbanVisionApi.Usecase.Organizations.CreateOrganization do
         {:ok, org}
 
       {:error, reason} = error ->
-        Logger.error("Failed to create organization",
-          correlation_id: correlation_id,
-          organization_name: cmd.name,
-          reason: reason
-        )
+        metadata =
+          [correlation_id: correlation_id, organization_name: cmd.name] ++
+            ErrorMetadata.from_reason(reason)
+
+        Logger.error("Failed to create organization", metadata)
 
         error
     end

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/delete_organization.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/delete_organization.ex
@@ -9,12 +9,14 @@ defmodule KanbanVisionApi.Usecase.Organizations.DeleteOrganization do
   require Logger
 
   alias KanbanVisionApi.Domain.Organization
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
   alias KanbanVisionApi.Domain.Ports.OrganizationRepository
+  alias KanbanVisionApi.Usecase.ErrorMetadata
   alias KanbanVisionApi.Usecase.EventEmitter
   alias KanbanVisionApi.Usecase.Organization.DeleteOrganizationCommand
   alias KanbanVisionApi.Usecase.RepositoryConfig
 
-  @type result :: {:ok, Organization.t()} | {:error, String.t()}
+  @type result :: ApplicationError.result(Organization.t())
 
   @spec execute(
           DeleteOrganizationCommand.t(),
@@ -52,11 +54,11 @@ defmodule KanbanVisionApi.Usecase.Organizations.DeleteOrganization do
         {:ok, org}
 
       {:error, reason} = error ->
-        Logger.error("Failed to delete organization",
-          correlation_id: correlation_id,
-          organization_id: cmd.id,
-          reason: reason
-        )
+        metadata =
+          [correlation_id: correlation_id, organization_id: cmd.id] ++
+            ErrorMetadata.from_reason(reason)
+
+        Logger.error("Failed to delete organization", metadata)
 
         error
     end

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_id.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_id.ex
@@ -8,11 +8,13 @@ defmodule KanbanVisionApi.Usecase.Organizations.GetOrganizationById do
   require Logger
 
   alias KanbanVisionApi.Domain.Organization
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
   alias KanbanVisionApi.Domain.Ports.OrganizationRepository
+  alias KanbanVisionApi.Usecase.ErrorMetadata
   alias KanbanVisionApi.Usecase.Organization.GetOrganizationByIdQuery
   alias KanbanVisionApi.Usecase.RepositoryConfig
 
-  @type result :: {:ok, Organization.t()} | {:error, String.t()}
+  @type result :: ApplicationError.result(Organization.t())
 
   @spec execute(
           GetOrganizationByIdQuery.t(),
@@ -38,11 +40,11 @@ defmodule KanbanVisionApi.Usecase.Organizations.GetOrganizationById do
         )
 
       {:error, reason} ->
-        Logger.warning("Organization not found",
-          correlation_id: correlation_id,
-          organization_id: query.id,
-          reason: reason
-        )
+        metadata =
+          [correlation_id: correlation_id, organization_id: query.id] ++
+            ErrorMetadata.from_reason(reason)
+
+        Logger.warning("Organization not found", metadata)
     end
 
     result

--- a/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_name.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/organizations/get_organization_by_name.ex
@@ -7,11 +7,13 @@ defmodule KanbanVisionApi.Usecase.Organizations.GetOrganizationByName do
 
   require Logger
 
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
   alias KanbanVisionApi.Domain.Ports.OrganizationRepository
+  alias KanbanVisionApi.Usecase.ErrorMetadata
   alias KanbanVisionApi.Usecase.Organization.GetOrganizationByNameQuery
   alias KanbanVisionApi.Usecase.RepositoryConfig
 
-  @type result :: {:ok, list()} | {:error, String.t()}
+  @type result :: ApplicationError.result(list())
 
   @spec execute(
           GetOrganizationByNameQuery.t(),
@@ -38,11 +40,11 @@ defmodule KanbanVisionApi.Usecase.Organizations.GetOrganizationByName do
         )
 
       {:error, reason} ->
-        Logger.warning("Organizations not found",
-          correlation_id: correlation_id,
-          organization_name: query.name,
-          reason: reason
-        )
+        metadata =
+          [correlation_id: correlation_id, organization_name: query.name] ++
+            ErrorMetadata.from_reason(reason)
+
+        Logger.warning("Organizations not found", metadata)
     end
 
     result

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulations/create_simulation.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulations/create_simulation.ex
@@ -8,13 +8,15 @@ defmodule KanbanVisionApi.Usecase.Simulations.CreateSimulation do
 
   require Logger
 
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
   alias KanbanVisionApi.Domain.Ports.SimulationRepository
   alias KanbanVisionApi.Domain.Simulation
+  alias KanbanVisionApi.Usecase.ErrorMetadata
   alias KanbanVisionApi.Usecase.EventEmitter
   alias KanbanVisionApi.Usecase.RepositoryConfig
   alias KanbanVisionApi.Usecase.Simulation.CreateSimulationCommand
 
-  @type result :: {:ok, Simulation.t()} | {:error, String.t()}
+  @type result :: ApplicationError.result(Simulation.t())
 
   @spec execute(CreateSimulationCommand.t(), SimulationRepository.repository_runtime(), keyword()) ::
           result()
@@ -53,12 +55,14 @@ defmodule KanbanVisionApi.Usecase.Simulations.CreateSimulation do
         {:ok, sim}
 
       {:error, reason} = error ->
-        Logger.error("Failed to create simulation",
-          correlation_id: correlation_id,
-          simulation_name: cmd.name,
-          organization_id: cmd.organization_id,
-          reason: reason
-        )
+        metadata =
+          [
+            correlation_id: correlation_id,
+            simulation_name: cmd.name,
+            organization_id: cmd.organization_id
+          ] ++ ErrorMetadata.from_reason(reason)
+
+        Logger.error("Failed to create simulation", metadata)
 
         error
     end

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulations/delete_simulation.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulations/delete_simulation.ex
@@ -8,13 +8,15 @@ defmodule KanbanVisionApi.Usecase.Simulations.DeleteSimulation do
 
   require Logger
 
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
   alias KanbanVisionApi.Domain.Ports.SimulationRepository
   alias KanbanVisionApi.Domain.Simulation
+  alias KanbanVisionApi.Usecase.ErrorMetadata
   alias KanbanVisionApi.Usecase.EventEmitter
   alias KanbanVisionApi.Usecase.RepositoryConfig
   alias KanbanVisionApi.Usecase.Simulation.DeleteSimulationCommand
 
-  @type result :: {:ok, Simulation.t()} | {:error, String.t()}
+  @type result :: ApplicationError.result(Simulation.t())
 
   @spec execute(DeleteSimulationCommand.t(), SimulationRepository.repository_runtime(), keyword()) ::
           result()
@@ -50,11 +52,11 @@ defmodule KanbanVisionApi.Usecase.Simulations.DeleteSimulation do
         {:ok, sim}
 
       {:error, reason} = error ->
-        Logger.error("Failed to delete simulation",
-          correlation_id: correlation_id,
-          simulation_id: cmd.id,
-          reason: reason
-        )
+        metadata =
+          [correlation_id: correlation_id, simulation_id: cmd.id] ++
+            ErrorMetadata.from_reason(reason)
+
+        Logger.error("Failed to delete simulation", metadata)
 
         error
     end

--- a/apps/usecase/lib/kanban_vision_api/usecase/simulations/get_simulation_by_org_and_name.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/simulations/get_simulation_by_org_and_name.ex
@@ -7,12 +7,13 @@ defmodule KanbanVisionApi.Usecase.Simulations.GetSimulationByOrgAndName do
 
   require Logger
 
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
   alias KanbanVisionApi.Domain.Ports.SimulationRepository
+  alias KanbanVisionApi.Usecase.ErrorMetadata
   alias KanbanVisionApi.Usecase.RepositoryConfig
   alias KanbanVisionApi.Usecase.Simulation.GetSimulationByOrgAndNameQuery
 
-  @type result ::
-          {:ok, KanbanVisionApi.Domain.Simulation.t()} | {:error, String.t()}
+  @type result :: ApplicationError.result(KanbanVisionApi.Domain.Simulation.t())
 
   @spec execute(
           GetSimulationByOrgAndNameQuery.t(),
@@ -48,12 +49,14 @@ defmodule KanbanVisionApi.Usecase.Simulations.GetSimulationByOrgAndName do
         {:ok, simulation}
 
       {:error, reason} = error ->
-        Logger.warning("Simulation not found",
-          correlation_id: correlation_id,
-          organization_id: query.organization_id,
-          simulation_name: query.name,
-          reason: reason
-        )
+        metadata =
+          [
+            correlation_id: correlation_id,
+            organization_id: query.organization_id,
+            simulation_name: query.name
+          ] ++ ErrorMetadata.from_reason(reason)
+
+        Logger.warning("Simulation not found", metadata)
 
         error
     end

--- a/apps/usecase/test/kanban_vision_api/usecase/organization_test.exs
+++ b/apps/usecase/test/kanban_vision_api/usecase/organization_test.exs
@@ -1,6 +1,7 @@
 defmodule KanbanVisionApi.Usecase.OrganizationTest do
   use ExUnit.Case, async: true
 
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
   alias KanbanVisionApi.Usecase.Organization
   alias KanbanVisionApi.Usecase.Organization.CreateOrganizationCommand
   alias KanbanVisionApi.Usecase.Organization.DeleteOrganizationCommand
@@ -48,12 +49,22 @@ defmodule KanbanVisionApi.Usecase.OrganizationTest do
 
     test "should return error for non-existent id", %{pid: pid} do
       {:ok, query} = GetOrganizationByIdQuery.new("invalid")
-      assert {:error, _} = Organization.get_by_id(pid, query)
+
+      assert Organization.get_by_id(pid, query) ==
+               ApplicationError.not_found(
+                 "Organization with id: invalid not found",
+                 %{entity: :organization, id: "invalid"}
+               )
     end
 
     test "should return error for non-existent name", %{pid: pid} do
       {:ok, query} = GetOrganizationByNameQuery.new("Invalid")
-      assert {:error, _} = Organization.get_by_name(pid, query)
+
+      assert Organization.get_by_name(pid, query) ==
+               ApplicationError.not_found(
+                 "Organization with name: Invalid not found",
+                 %{entity: :organization, field: :name, name: "Invalid"}
+               )
     end
 
     test "should not allow duplicate organization names", %{pid: pid} do
@@ -61,7 +72,12 @@ defmodule KanbanVisionApi.Usecase.OrganizationTest do
       {:ok, _} = Organization.add(pid, cmd)
 
       {:ok, cmd2} = CreateOrganizationCommand.new("TestOrg")
-      assert {:error, _} = Organization.add(pid, cmd2)
+
+      assert Organization.add(pid, cmd2) ==
+               ApplicationError.conflict(
+                 "Organization with name: TestOrg already exist",
+                 %{entity: :organization, field: :name, name: "TestOrg"}
+               )
     end
 
     test "should reject invalid command", %{pid: _pid} do

--- a/apps/usecase/test/kanban_vision_api/usecase/simulation_test.exs
+++ b/apps/usecase/test/kanban_vision_api/usecase/simulation_test.exs
@@ -2,6 +2,7 @@ defmodule KanbanVisionApi.Usecase.SimulationTest do
   use ExUnit.Case, async: true
 
   alias KanbanVisionApi.Domain.Organization
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
   alias KanbanVisionApi.Usecase.Simulation
   alias KanbanVisionApi.Usecase.Simulation.CreateSimulationCommand
   alias KanbanVisionApi.Usecase.Simulation.GetSimulationByOrgAndNameQuery
@@ -35,7 +36,12 @@ defmodule KanbanVisionApi.Usecase.SimulationTest do
 
     test "should return error for non-existent simulation", %{pid: pid} do
       {:ok, query} = GetSimulationByOrgAndNameQuery.new("invalid", "Invalid")
-      assert {:error, _} = Simulation.get_by_org_and_name(pid, query)
+
+      assert Simulation.get_by_org_and_name(pid, query) ==
+               ApplicationError.not_found(
+                 "Simulation with organization id: invalid not found",
+                 %{entity: :simulation, field: :organization_id, organization_id: "invalid"}
+               )
     end
 
     test "should reject invalid command", %{pid: _pid} do

--- a/apps/web_api/lib/kanban_vision_api/web_api/error_mapper.ex
+++ b/apps/web_api/lib/kanban_vision_api/web_api/error_mapper.ex
@@ -36,4 +36,5 @@ defmodule KanbanVisionApi.WebApi.ErrorMapper do
   def http_status(%ApplicationError{code: :not_found}), do: 404
   def http_status(%ApplicationError{code: :conflict}), do: 409
   def http_status(%ApplicationError{code: :internal_error}), do: 500
+  def http_status(%ApplicationError{}), do: 500
 end

--- a/apps/web_api/lib/kanban_vision_api/web_api/error_mapper.ex
+++ b/apps/web_api/lib/kanban_vision_api/web_api/error_mapper.ex
@@ -1,0 +1,39 @@
+defmodule KanbanVisionApi.WebApi.ErrorMapper do
+  @moduledoc false
+
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
+
+  @spec normalize(term()) :: ApplicationError.t()
+  def normalize(%ApplicationError{} = error), do: error
+
+  def normalize(:invalid_name),
+    do: ApplicationError.new(:invalid_input, "Invalid name", %{reason: :invalid_name})
+
+  def normalize(:invalid_id),
+    do: ApplicationError.new(:invalid_input, "Invalid ID", %{reason: :invalid_id})
+
+  def normalize(:invalid_tribes),
+    do: ApplicationError.new(:invalid_input, "Invalid tribes", %{reason: :invalid_tribes})
+
+  def normalize(:invalid_organization_id) do
+    ApplicationError.new(
+      :invalid_input,
+      "Invalid organization ID",
+      %{reason: :invalid_organization_id}
+    )
+  end
+
+  def normalize(reason) when is_binary(reason) do
+    ApplicationError.new(:internal_error, reason, %{legacy_reason: :binary})
+  end
+
+  def normalize(_reason) do
+    ApplicationError.new(:internal_error, "Internal server error", %{})
+  end
+
+  @spec http_status(ApplicationError.t()) :: pos_integer()
+  def http_status(%ApplicationError{code: :invalid_input}), do: 422
+  def http_status(%ApplicationError{code: :not_found}), do: 404
+  def http_status(%ApplicationError{code: :conflict}), do: 409
+  def http_status(%ApplicationError{code: :internal_error}), do: 500
+end

--- a/apps/web_api/lib/kanban_vision_api/web_api/organizations/organization_controller.ex
+++ b/apps/web_api/lib/kanban_vision_api/web_api/organizations/organization_controller.ex
@@ -3,7 +3,8 @@ defmodule KanbanVisionApi.WebApi.Organizations.OrganizationController do
   HTTP adapter: translates HTTP requests to Organization use case calls.
 
   Pure adapter — no business logic. Maps HTTP → Command/Query → use case → JSON response.
-  Error mapping: :invalid_* → 422, "not found" → 404, "already exist" → 409, other → 500.
+  Error mapping: validation atoms normalize to `:invalid_input`, structured application
+  errors map by `code`, and transport logic never parses message text.
   """
 
   import Plug.Conn
@@ -12,6 +13,7 @@ defmodule KanbanVisionApi.WebApi.Organizations.OrganizationController do
   alias KanbanVisionApi.Usecase.Organization.DeleteOrganizationCommand
   alias KanbanVisionApi.Usecase.Organization.GetOrganizationByIdQuery
   alias KanbanVisionApi.Usecase.Organization.GetOrganizationByNameQuery
+  alias KanbanVisionApi.WebApi.ErrorMapper
   alias KanbanVisionApi.WebApi.Organizations.OrganizationSerializer
 
   @spec call(Plug.Conn.t(), atom()) :: Plug.Conn.t()
@@ -84,21 +86,7 @@ defmodule KanbanVisionApi.WebApi.Organizations.OrganizationController do
   end
 
   defp respond_error(conn, reason) do
-    {status, message} = map_error(reason)
-    respond(conn, status, %{error: message})
+    error = ErrorMapper.normalize(reason)
+    respond(conn, ErrorMapper.http_status(error), %{error: error.message})
   end
-
-  defp map_error(:invalid_name), do: {422, "Invalid name"}
-  defp map_error(:invalid_id), do: {422, "Invalid ID"}
-  defp map_error(:invalid_tribes), do: {422, "Invalid tribes"}
-
-  defp map_error(reason) when is_binary(reason) do
-    cond do
-      String.contains?(reason, "not found") -> {404, reason}
-      String.contains?(reason, "already exist") -> {409, reason}
-      true -> {500, reason}
-    end
-  end
-
-  defp map_error(_), do: {500, "Internal server error"}
 end

--- a/apps/web_api/lib/kanban_vision_api/web_api/ports/organization_usecase.ex
+++ b/apps/web_api/lib/kanban_vision_api/web_api/ports/organization_usecase.ex
@@ -6,22 +6,25 @@ defmodule KanbanVisionApi.WebApi.Ports.OrganizationUsecase do
   enabling Mox-based unit testing of controllers.
   """
 
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
   alias KanbanVisionApi.Usecase.Organization.CreateOrganizationCommand
   alias KanbanVisionApi.Usecase.Organization.DeleteOrganizationCommand
   alias KanbanVisionApi.Usecase.Organization.GetOrganizationByIdQuery
   alias KanbanVisionApi.Usecase.Organization.GetOrganizationByNameQuery
 
+  @type error_reason :: ApplicationError.t() | atom()
+
   @callback get_all(opts :: keyword()) :: {:ok, map()}
 
   @callback get_by_id(GetOrganizationByIdQuery.t(), opts :: keyword()) ::
-              {:ok, any()} | {:error, String.t()}
+              {:ok, any()} | {:error, error_reason()}
 
   @callback get_by_name(GetOrganizationByNameQuery.t(), opts :: keyword()) ::
-              {:ok, list()} | {:error, String.t()}
+              {:ok, list()} | {:error, error_reason()}
 
   @callback add(CreateOrganizationCommand.t(), opts :: keyword()) ::
-              {:ok, any()} | {:error, String.t()}
+              {:ok, any()} | {:error, error_reason()}
 
   @callback delete(DeleteOrganizationCommand.t(), opts :: keyword()) ::
-              {:ok, any()} | {:error, String.t()}
+              {:ok, any()} | {:error, error_reason()}
 end

--- a/apps/web_api/lib/kanban_vision_api/web_api/ports/simulation_usecase.ex
+++ b/apps/web_api/lib/kanban_vision_api/web_api/ports/simulation_usecase.ex
@@ -6,18 +6,21 @@ defmodule KanbanVisionApi.WebApi.Ports.SimulationUsecase do
   enabling Mox-based unit testing of controllers.
   """
 
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
   alias KanbanVisionApi.Usecase.Simulation.CreateSimulationCommand
   alias KanbanVisionApi.Usecase.Simulation.DeleteSimulationCommand
   alias KanbanVisionApi.Usecase.Simulation.GetSimulationByOrgAndNameQuery
 
+  @type error_reason :: ApplicationError.t() | atom()
+
   @callback get_all(opts :: keyword()) :: {:ok, map()}
 
   @callback get_by_org_and_name(GetSimulationByOrgAndNameQuery.t(), opts :: keyword()) ::
-              {:ok, any()} | {:error, String.t()}
+              {:ok, any()} | {:error, error_reason()}
 
   @callback add(CreateSimulationCommand.t(), opts :: keyword()) ::
-              {:ok, any()} | {:error, String.t()}
+              {:ok, any()} | {:error, error_reason()}
 
   @callback delete(DeleteSimulationCommand.t(), opts :: keyword()) ::
-              {:ok, any()} | {:error, String.t()}
+              {:ok, any()} | {:error, error_reason()}
 end

--- a/apps/web_api/lib/kanban_vision_api/web_api/simulations/simulation_controller.ex
+++ b/apps/web_api/lib/kanban_vision_api/web_api/simulations/simulation_controller.ex
@@ -3,7 +3,8 @@ defmodule KanbanVisionApi.WebApi.Simulations.SimulationController do
   HTTP adapter: translates HTTP requests to Simulation use case calls.
 
   Pure adapter — no business logic. Maps HTTP → Command/Query → use case → JSON response.
-  Error mapping: :invalid_* → 422, "not found" → 404, "already exist" → 409, other → 500.
+  Error mapping: validation atoms normalize to `:invalid_input`, structured application
+  errors map by `code`, and transport logic never parses message text.
   """
 
   import Plug.Conn
@@ -11,6 +12,7 @@ defmodule KanbanVisionApi.WebApi.Simulations.SimulationController do
   alias KanbanVisionApi.Usecase.Simulation.CreateSimulationCommand
   alias KanbanVisionApi.Usecase.Simulation.DeleteSimulationCommand
   alias KanbanVisionApi.Usecase.Simulation.GetSimulationByOrgAndNameQuery
+  alias KanbanVisionApi.WebApi.ErrorMapper
   alias KanbanVisionApi.WebApi.Simulations.SimulationSerializer
 
   @spec call(Plug.Conn.t(), atom()) :: Plug.Conn.t()
@@ -74,21 +76,7 @@ defmodule KanbanVisionApi.WebApi.Simulations.SimulationController do
   end
 
   defp respond_error(conn, reason) do
-    {status, message} = map_error(reason)
-    respond(conn, status, %{error: message})
+    error = ErrorMapper.normalize(reason)
+    respond(conn, ErrorMapper.http_status(error), %{error: error.message})
   end
-
-  defp map_error(:invalid_name), do: {422, "Invalid name"}
-  defp map_error(:invalid_id), do: {422, "Invalid ID"}
-  defp map_error(:invalid_organization_id), do: {422, "Invalid organization ID"}
-
-  defp map_error(reason) when is_binary(reason) do
-    cond do
-      String.contains?(reason, "not found") -> {404, reason}
-      String.contains?(reason, "already exist") -> {409, reason}
-      true -> {500, reason}
-    end
-  end
-
-  defp map_error(_), do: {500, "Internal server error"}
 end

--- a/apps/web_api/test/kanban_vision_api/web_api/integration/organizations_integration_test.exs
+++ b/apps/web_api/test/kanban_vision_api/web_api/integration/organizations_integration_test.exs
@@ -66,8 +66,10 @@ defmodule KanbanVisionApi.WebApi.Integration.OrganizationsIntegrationTest do
         |> Router.call(@opts)
 
       assert conn.status == 409
-      assert Jason.decode!(conn.resp_body)["error"] ==
-               "Organization with name: Duplicated Integration Org already exist"
+
+      body = Jason.decode!(conn.resp_body)
+      assert is_binary(body["error"])
+      assert body["error"] != ""
 
       cleanup_organization(org["id"])
     end

--- a/apps/web_api/test/kanban_vision_api/web_api/integration/organizations_integration_test.exs
+++ b/apps/web_api/test/kanban_vision_api/web_api/integration/organizations_integration_test.exs
@@ -55,6 +55,22 @@ defmodule KanbanVisionApi.WebApi.Integration.OrganizationsIntegrationTest do
 
       assert conn.status == 422
     end
+
+    test "returns 409 when organization already exists" do
+      org = create_organization("Duplicated Integration Org")
+
+      conn =
+        :post
+        |> conn("/api/v1/organizations", Jason.encode!(%{name: "Duplicated Integration Org"}))
+        |> put_req_header("content-type", "application/json")
+        |> Router.call(@opts)
+
+      assert conn.status == 409
+      assert Jason.decode!(conn.resp_body)["error"] ==
+               "Organization with name: Duplicated Integration Org already exist"
+
+      cleanup_organization(org["id"])
+    end
   end
 
   describe "GET /api/v1/organizations/:id" do

--- a/apps/web_api/test/kanban_vision_api/web_api/integration/simulations_integration_test.exs
+++ b/apps/web_api/test/kanban_vision_api/web_api/integration/simulations_integration_test.exs
@@ -65,6 +65,28 @@ defmodule KanbanVisionApi.WebApi.Integration.SimulationsIntegrationTest do
 
       cleanup_organization(org["id"])
     end
+
+    test "returns 409 when simulation already exists" do
+      org = create_organization("SimConflictOrg")
+      sim = create_simulation("RepeatedSimulation", org["id"])
+
+      conn =
+        :post
+        |> conn(
+          "/api/v1/simulations",
+          Jason.encode!(%{name: "RepeatedSimulation", organization_id: org["id"]})
+        )
+        |> put_req_header("content-type", "application/json")
+        |> Router.call(@opts)
+
+      assert conn.status == 409
+
+      assert Jason.decode!(conn.resp_body)["error"] ==
+               "Simulation with organization_id: #{org["id"]} name: RepeatedSimulation already exist"
+
+      cleanup_simulation(sim["id"])
+      cleanup_organization(org["id"])
+    end
   end
 
   describe "GET /api/v1/simulations/search" do

--- a/apps/web_api/test/kanban_vision_api/web_api/integration/simulations_integration_test.exs
+++ b/apps/web_api/test/kanban_vision_api/web_api/integration/simulations_integration_test.exs
@@ -80,9 +80,9 @@ defmodule KanbanVisionApi.WebApi.Integration.SimulationsIntegrationTest do
         |> Router.call(@opts)
 
       assert conn.status == 409
-
-      assert Jason.decode!(conn.resp_body)["error"] ==
-               "Simulation with organization_id: #{org["id"]} name: RepeatedSimulation already exist"
+      body = Jason.decode!(conn.resp_body)
+      assert is_binary(body["error"])
+      assert body["error"] != ""
 
       cleanup_simulation(sim["id"])
       cleanup_organization(org["id"])

--- a/apps/web_api/test/kanban_vision_api/web_api/organizations/organization_controller_test.exs
+++ b/apps/web_api/test/kanban_vision_api/web_api/organizations/organization_controller_test.exs
@@ -6,6 +6,7 @@ defmodule KanbanVisionApi.WebApi.Organizations.OrganizationControllerTest do
   import Plug.Test
 
   alias KanbanVisionApi.Domain.Organization
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
   alias KanbanVisionApi.WebApi.Organizations.OrganizationController
   alias KanbanVisionApi.WebApi.OrganizationUsecaseMock
 
@@ -83,7 +84,7 @@ defmodule KanbanVisionApi.WebApi.Organizations.OrganizationControllerTest do
 
     test "returns 404 when no organizations found" do
       expect(OrganizationUsecaseMock, :get_by_name, fn _query, _opts ->
-        {:error, "not found"}
+        ApplicationError.not_found("Organization with name: Unknown not found", %{})
       end)
 
       conn =
@@ -117,7 +118,7 @@ defmodule KanbanVisionApi.WebApi.Organizations.OrganizationControllerTest do
 
     test "returns 404 when organization not found", %{org: org} do
       expect(OrganizationUsecaseMock, :get_by_id, fn _query, _opts ->
-        {:error, "not found"}
+        ApplicationError.not_found("Organization with id: #{org.id} not found", %{})
       end)
 
       conn =
@@ -174,7 +175,7 @@ defmodule KanbanVisionApi.WebApi.Organizations.OrganizationControllerTest do
 
     test "returns 409 when organization already exists", %{org: org} do
       expect(OrganizationUsecaseMock, :add, fn _cmd, _opts ->
-        {:error, "already exist"}
+        ApplicationError.conflict("Organization with name: #{org.name} already exist", %{})
       end)
 
       conn =
@@ -208,7 +209,7 @@ defmodule KanbanVisionApi.WebApi.Organizations.OrganizationControllerTest do
 
     test "returns 404 when organization not found", %{org: org} do
       expect(OrganizationUsecaseMock, :delete, fn _cmd, _opts ->
-        {:error, "not found"}
+        ApplicationError.not_found("Organization with id: #{org.id} not found", %{})
       end)
 
       conn =
@@ -236,7 +237,7 @@ defmodule KanbanVisionApi.WebApi.Organizations.OrganizationControllerTest do
 
     test "returns 500 for a generic binary server error" do
       expect(OrganizationUsecaseMock, :delete, fn _cmd, _opts ->
-        {:error, "unexpected server failure"}
+        ApplicationError.internal_error("unexpected server failure", %{})
       end)
 
       conn =
@@ -247,6 +248,7 @@ defmodule KanbanVisionApi.WebApi.Organizations.OrganizationControllerTest do
         |> OrganizationController.call(:delete)
 
       assert conn.status == 500
+      assert Jason.decode!(conn.resp_body)["error"] == "unexpected server failure"
     end
 
     test "returns 500 for an unknown error type" do

--- a/apps/web_api/test/kanban_vision_api/web_api/simulations/simulation_controller_test.exs
+++ b/apps/web_api/test/kanban_vision_api/web_api/simulations/simulation_controller_test.exs
@@ -4,6 +4,7 @@ defmodule KanbanVisionApi.WebApi.Simulations.SimulationControllerTest do
   import Mox
   import Plug.Test
 
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
   alias KanbanVisionApi.Domain.Simulation
   alias KanbanVisionApi.WebApi.Simulations.SimulationController
   alias KanbanVisionApi.WebApi.SimulationUsecaseMock
@@ -82,7 +83,7 @@ defmodule KanbanVisionApi.WebApi.Simulations.SimulationControllerTest do
 
     test "returns 404 when simulation not found" do
       expect(SimulationUsecaseMock, :get_by_org_and_name, fn _query, _opts ->
-        {:error, "not found"}
+        ApplicationError.not_found("Simulation with name: Missing not found", %{})
       end)
 
       conn =
@@ -138,7 +139,10 @@ defmodule KanbanVisionApi.WebApi.Simulations.SimulationControllerTest do
 
     test "returns 409 when simulation already exists" do
       expect(SimulationUsecaseMock, :add, fn _cmd, _opts ->
-        {:error, "already exist"}
+        ApplicationError.conflict(
+          "Simulation with organization_id: org-123 name: Sprint 1 already exist",
+          %{}
+        )
       end)
 
       conn =
@@ -172,7 +176,7 @@ defmodule KanbanVisionApi.WebApi.Simulations.SimulationControllerTest do
 
     test "returns 404 when simulation not found", %{sim: sim} do
       expect(SimulationUsecaseMock, :delete, fn _cmd, _opts ->
-        {:error, "not found"}
+        ApplicationError.not_found("Simulation with id: #{sim.id} not found", %{})
       end)
 
       conn =
@@ -200,7 +204,7 @@ defmodule KanbanVisionApi.WebApi.Simulations.SimulationControllerTest do
   describe "error mapping" do
     test "returns 500 for a generic binary server error" do
       expect(SimulationUsecaseMock, :delete, fn _cmd, _opts ->
-        {:error, "unexpected server failure"}
+        ApplicationError.internal_error("unexpected server failure", %{})
       end)
 
       conn =
@@ -211,6 +215,7 @@ defmodule KanbanVisionApi.WebApi.Simulations.SimulationControllerTest do
         |> SimulationController.call(:delete)
 
       assert conn.status == 500
+      assert Jason.decode!(conn.resp_body)["error"] == "unexpected server failure"
     end
 
     test "returns 500 for an unknown error type" do

--- a/training/dia3_modulo_01_web_api.md
+++ b/training/dia3_modulo_01_web_api.md
@@ -421,32 +421,31 @@ defmodule KanbanVisionApi.WebApi.Organizations.OrganizationController do
     end
   end
 
-  # Mapeia erros de domínio para HTTP status codes
-  defp map_error(:invalid_name), do: {422, "Invalid name"}
-  defp map_error(:invalid_id),   do: {422, "Invalid ID"}
-
-  defp map_error(reason) when is_binary(reason) do
-    cond do
-      String.contains?(reason, "not found")    -> {404, reason}
-      String.contains?(reason, "already exist") -> {409, reason}
-      true                                      -> {500, reason}
-    end
+  # Normaliza erros de aplicação e mapeia o status por código sem fazer parsing de texto
+  defp respond_error(conn, reason) do
+    error = ErrorMapper.normalize(reason)
+    respond(conn, ErrorMapper.http_status(error), %{error: error.message})
   end
 end
 ```
 
 ### O mapeamento de erros
 
-O domínio retorna átomos (`:invalid_name`) ou strings ("Organization not found").
-O controller traduz isso para HTTP status codes sem que o domínio saiba de HTTP:
+Os command/query DTOs ainda podem retornar átomos de validação (`:invalid_name`),
+mas os adapters externos devem trabalhar com erros estruturados:
+
+```elixir
+{:error, %{code: :not_found, message: "...", details: %{...}}}
+```
+
+O controller traduz isso para HTTP status codes usando `code`, sem depender do texto:
 
 ```
-Domínio            →   HTTP
-:invalid_name      →   422 Unprocessable Entity
-:invalid_id        →   422 Unprocessable Entity
-"not found"        →   404 Not Found
-"already exist"    →   409 Conflict
-outros             →   500 Internal Server Error
+Erro estruturado   →   HTTP
+:invalid_input     →   422 Unprocessable Entity
+:not_found         →   404 Not Found
+:conflict          →   409 Conflict
+:internal_error    →   500 Internal Server Error
 ```
 
 ### O padrão `with` para pipelines de sucesso
@@ -755,7 +754,9 @@ defmodule KanbanVisionApi.WebApi.Organizations.OrganizationControllerTest do
   describe "GET /api/v1/organizations/:id" do
     test "retorna 404 quando não encontrado" do
       MockOrganizationUsecase
-      |> expect(:get_by_id, fn _query, _opts -> {:error, "Organization not found"} end)
+      |> expect(:get_by_id, fn _query, _opts ->
+        {:error, %{code: :not_found, message: "Organization not found", details: %{}}}
+      end)
 
       conn =
         :get

--- a/training/dia3_modulo_01_web_api.md
+++ b/training/dia3_modulo_01_web_api.md
@@ -435,7 +435,7 @@ Os command/query DTOs ainda podem retornar átomos de validação (`:invalid_nam
 mas os adapters externos devem trabalhar com erros estruturados:
 
 ```elixir
-{:error, %{code: :not_found, message: "...", details: %{...}}}
+{:error, %ApplicationError{code: :not_found, message: "...", details: %{...}}}
 ```
 
 O controller traduz isso para HTTP status codes usando `code`, sem depender do texto:


### PR DESCRIPTION
## Summary
- adopt a shared structured application error contract across persistence, usecase, and web_api
- replace HTTP status inference by message parsing with explicit error-code mapping
- update ADR 0003, project guidance, tests, and training material for the new boundary

## Validation
- mix format
- mix compile
- mix test
- mix credo --strict
- mix dialyzer
- env MIX_ENV=test mix coveralls --umbrella

## Notes
- env MIX_ENV=test mix coveralls.github --umbrella depends on GitHub Actions metadata such as GITHUB_EVENT_PATH; the local run executed tests but fails outside CI for that reason, so local coverage verification used mix coveralls --umbrella instead.