### PR TITLE
feat: complete board context architecture

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -2,51 +2,200 @@ name: Elixir CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions:
   contents: read
 
-jobs:
-  build:
+env:
+  ELIXIR_VERSION: "1.18.4"
+  OTP_VERSION: "28.0.2_1"
+  IMAGE_OS: ubuntu22
 
-    name: Build and test
+jobs:
+  credo:
+    name: Credo
     runs-on: ubuntu-latest
 
-    env:
-      ImageOS: ubuntu22
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Elixir
-      uses: erlef/setup-beam@v1
-      with:
-        elixir-version: '1.18.4' # Define the elixir version [required]
-        otp-version: '28.0.2_1' # Define the OTP version [required]
-    - name: Restore dependencies cache
-      uses: actions/cache@v3
-      with:
-        path: deps
-        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-mix-
-    - name: Restore PLT cache
-      uses: actions/cache@v3
-      with:
-        path: _build/dev/dialyxir_*.plt*
-        key: ${{ runner.os }}-plt-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-plt-
-    - name: Install dependencies
-      run: mix deps.get
-    - name: Compile dependencies
-      run: mix deps.compile
-    - name: Run Credo
-      run: mix credo
-    - name: Run Dialyzer
-      run: mix dialyzer
-    - name: Run Coverage
-      run: MIX_ENV=test mix coveralls.github --umbrella
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Run tests
-      run: mix test --cover
+      - uses: actions/checkout@v3
+
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          otp-version: ${{ env.OTP_VERSION }}
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v3
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Compile dependencies
+        run: mix deps.compile
+
+      - name: Run Credo
+        run: mix credo
+
+      - name: Write job summary
+        if: success()
+        run: |
+          {
+            echo "## Credo"
+            echo
+            echo "- Status: passed"
+            echo "- Command: \`mix credo\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  dialyzer:
+    name: Dialyzer
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          otp-version: ${{ env.OTP_VERSION }}
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v3
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
+
+      - name: Restore PLT cache
+        uses: actions/cache@v3
+        with:
+          path: _build/dev/dialyxir_*.plt*
+          key: ${{ runner.os }}-plt-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-plt-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Compile dependencies
+        run: mix deps.compile
+
+      - name: Run Dialyzer
+        run: mix dialyzer
+
+      - name: Write job summary
+        if: success()
+        run: |
+          {
+            echo "## Dialyzer"
+            echo
+            echo "- Status: passed"
+            echo "- Command: \`mix dialyzer\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          otp-version: ${{ env.OTP_VERSION }}
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v3
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Compile dependencies
+        run: mix deps.compile
+
+      - name: Run Coverage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: MIX_ENV=test mix coveralls.github --umbrella
+
+      - name: Write job summary
+        if: success()
+        run: |
+          {
+            echo "## Coverage"
+            echo
+            echo "- Status: passed"
+            echo "- Command: \`MIX_ENV=test mix coveralls.github --umbrella\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          otp-version: ${{ env.OTP_VERSION }}
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v3
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Compile dependencies
+        run: mix deps.compile
+
+      - name: Run tests
+        run: mix test --cover
+
+      - name: Write job summary
+        if: success()
+        run: |
+          {
+            echo "## Tests"
+            echo
+            echo "- Status: passed"
+            echo "- Command: \`mix test --cover\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  ci-summary:
+    name: CI Summary
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [credo, dialyzer, coverage, test]
+
+    steps:
+      - name: Write workflow summary
+        run: |
+          {
+            echo "# Elixir CI Summary"
+            echo
+            echo "| Check | Result |"
+            echo "| --- | --- |"
+            echo "| Credo | ${{ needs.credo.result }} |"
+            echo "| Dialyzer | ${{ needs.dialyzer.result }} |"
+            echo "| Coverage | ${{ needs.coverage.result }} |"
+            echo "| Test | ${{ needs.test.result }} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/adr/0004-complete-board-context-as-a-first-class-bounded-context.md
+++ b/adr/0004-complete-board-context-as-a-first-class-bounded-context.md
@@ -1,0 +1,195 @@
+# 0004. Complete Board Context As A First-Class Bounded Context
+
+- Status: accepted
+- Date: 2026-03-27
+- Supersedes: none
+- Related:
+  - 0001-use-cqs-and-hexagonal-boundaries-with-in-memory-persistence
+  - 0002-remove-pid-leakage-from-domain-repository-ports
+  - 0003-adopt-structured-application-errors
+
+## Context
+
+ADR 0001 established that this project should scream the business domain through
+explicit bounded contexts, use-case-first orchestration, and transport adapters
+that only translate inputs and outputs.
+
+After ADR 0002 and ADR 0003, `organization` and `simulation` already exposed a
+complete architectural slice:
+
+- explicit command/query DTOs
+- dedicated use-case modules
+- a supervised application orchestrator
+- HTTP adapters and OpenAPI surface
+- structured errors across boundaries
+
+`board`, however, still lagged behind that shape. The domain entity and the
+persistence adapter existed, but the public application boundary was incomplete.
+That meant:
+
+- the `board` context did not appear with the same clarity as the other
+  bounded contexts
+- use cases were partial and not organized in the same CQS shape
+- the HTTP layer did not expose `board` as a first-class capability
+- the architecture still did not fully scream the current domain model
+
+The project continues to use in-memory persistence during runtime, with opaque
+repository runtimes hiding process details. This ADR does not change that
+runtime strategy. It completes the architectural slice for `board` using the
+same conventions already adopted in the rest of the system.
+
+## Decision
+
+We will complete the `board` context as a first-class bounded context with the
+same architectural shape used by `organization` and `simulation`.
+
+The `board` context must include:
+
+- a dedicated `KanbanVisionApi.Usecase.Board` GenServer orchestrator
+- explicit command/query DTOs
+- explicit use-case modules for board commands and queries
+- a dedicated HTTP port, adapter, controller, and serializer
+- OpenAPI documentation for the public board endpoints
+- automated tests for usecase, controller, integration, router, and serializer
+
+The chosen HTTP shape is:
+
+- nested routes under simulation for board collection operations
+- top-level routes for direct board lookup and deletion
+
+The initial board HTTP surface is:
+
+- `GET /api/v1/simulations/:simulation_id/boards`
+- `POST /api/v1/simulations/:simulation_id/boards`
+- `GET /api/v1/boards/:id`
+- `DELETE /api/v1/boards/:id`
+
+The create contract is intentionally minimal:
+
+- request body contains only `name`
+- `simulation_id` is authoritative from the route
+- `workflow` and `workers` remain internal defaults for this phase
+
+The board HTTP response remains intentionally narrow for now and exposes:
+
+- `id`
+- `name`
+- `simulation_id`
+- `created_at`
+- `updated_at`
+
+This ADR does not introduce:
+
+- board update semantics
+- board workflow mutation over HTTP
+- board worker allocation over HTTP
+- new persistence mechanisms beyond the current Agent-backed runtime
+
+## Considered Options
+
+### Option A
+
+Keep `board` as a partial/internal context and only expose the existing delete
+flow.
+
+Why it was not chosen:
+
+- keeps the architecture uneven across bounded contexts
+- weakens Screaming Architecture by hiding a real domain capability
+- increases future implementation cost because every new board flow would remain
+  ad hoc
+
+### Option B
+
+Complete `board` now with the same CQS and hexagonal structure already used by
+the other contexts.
+
+Why it is preferred:
+
+- aligns the codebase around one architectural shape
+- makes `board` visible as a first-class domain concept
+- reduces special cases in usecase and HTTP layers
+- strengthens consistency for future board-related evolution
+
+## Consequences
+
+### Positive
+
+- The application now screams `board` as a proper bounded context.
+- `board`, `organization`, and `simulation` follow the same structural pattern.
+- HTTP and OpenAPI now reflect the existing domain capability more clearly.
+- Future board evolution can build on a stable CQS and adapter boundary.
+- Tests can cover board behavior through the same layers used by the other
+  contexts.
+
+### Negative
+
+- The change touches multiple apps in the umbrella at once.
+- More public surface area now needs to be maintained in tests and docs.
+- Future decisions about board workflow and worker management remain deferred,
+  so the public board contract is intentionally incomplete for now.
+
+## Execution Plan
+
+### Phase 1: Board Application Boundary
+
+- Add a dedicated `KanbanVisionApi.Usecase.Board` orchestrator.
+- Wire `:board` repository resolution through the same configuration path used
+  by the other contexts.
+- Keep the current in-memory Agent adapter and opaque repository runtime model.
+
+Status:
+- Completed.
+
+### Phase 2: Board CQS Surface
+
+- Add explicit command and query DTOs for board operations.
+- Add use-case modules for create, list, get-by-id, get-by-simulation, and
+  delete.
+- Keep structured logging and telemetry aligned with the existing usecase
+  boundary.
+
+Status:
+- Completed.
+
+### Phase 3: Board HTTP Adapter
+
+- Add the HTTP port, adapter, controller, and serializer for board operations.
+- Expose nested simulation board routes and direct board routes.
+- Reuse structured error mapping from ADR 0003.
+
+Status:
+- Completed.
+
+### Phase 4: OpenAPI And Test Alignment
+
+- Document the board endpoints and schema in OpenAPI.
+- Add or update usecase, serializer, router, controller, and integration tests.
+- Validate the full repository quality gate after the change.
+
+Status:
+- Completed.
+
+## Acceptance Criteria
+
+- `board` has a dedicated usecase orchestrator supervised with the other
+  contexts.
+- `board` operations are modeled through explicit command/query DTOs and
+  use-case modules.
+- HTTP exposes collection operations under simulation and direct lookup/delete
+  routes for boards.
+- OpenAPI documents the board endpoints and response schema.
+- The full quality gate passes:
+  - `mix format`
+  - `mix compile`
+  - `mix test`
+  - `mix credo --strict`
+  - `mix dialyzer`
+  - `env MIX_ENV=test mix coveralls --umbrella`
+
+## Notes
+
+This ADR completes the next structural step after ADR 0003. It keeps the
+current runtime model and structured error contract while making the `board`
+context fully visible and consistent across the application's architectural
+boundaries.

--- a/adr/README.md
+++ b/adr/README.md
@@ -14,3 +14,4 @@ This directory stores the project's Architectural Decision Records (ADRs).
 - [0001-use-cqs-and-hexagonal-boundaries-with-in-memory-persistence](0001-use-cqs-and-hexagonal-boundaries-with-in-memory-persistence.md)
 - [0002-remove-pid-leakage-from-domain-repository-ports](0002-remove-pid-leakage-from-domain-repository-ports.md)
 - [0003-adopt-structured-application-errors](0003-adopt-structured-application-errors.md)
+- [0004-complete-board-context-as-a-first-class-bounded-context](0004-complete-board-context-as-a-first-class-bounded-context.md)

--- a/apps/persistence/lib/kanban_vision_api/agent/boards.ex
+++ b/apps/persistence/lib/kanban_vision_api/agent/boards.ex
@@ -148,7 +148,7 @@ defmodule KanbanVisionApi.Agent.Boards do
 
   defp conflict_by_name_and_simulation_id(name, simulation_id) do
     ApplicationError.conflict(
-      "Board with name: #{name} from simulation_id: #{simulation_id} already exist",
+      "Board with name: #{name} from simulation_id: #{simulation_id} already exists",
       %{entity: :board, field: :name, name: name, simulation_id: simulation_id}
     )
   end

--- a/apps/usecase/lib/kanban_vision_api/usecase/application.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/application.ex
@@ -10,6 +10,8 @@ defmodule KanbanVisionApi.Usecase.Application do
   @impl true
   def start(_type, _args) do
     children = [
+      {KanbanVisionApi.Usecase.Board,
+       name: KanbanVisionApi.Usecase.Board, repository: RepositoryConfig.fetch!(:board)},
       {KanbanVisionApi.Usecase.Organization,
        name: KanbanVisionApi.Usecase.Organization,
        repository: RepositoryConfig.fetch!(:organization)},

--- a/apps/usecase/lib/kanban_vision_api/usecase/board.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/board.ex
@@ -1,0 +1,91 @@
+defmodule KanbanVisionApi.Usecase.Board do
+  @moduledoc """
+  GenServer orchestrating board use cases.
+
+  Maintains repository state and delegates operations to specialized Use Case modules.
+  """
+
+  use GenServer
+
+  alias KanbanVisionApi.Usecase.Board.CreateBoardCommand
+  alias KanbanVisionApi.Usecase.Board.DeleteBoardCommand
+  alias KanbanVisionApi.Usecase.Board.GetBoardByIdQuery
+  alias KanbanVisionApi.Usecase.Board.GetBoardsBySimulationIdQuery
+  alias KanbanVisionApi.Usecase.Boards.CreateBoard
+  alias KanbanVisionApi.Usecase.Boards.DeleteBoard
+  alias KanbanVisionApi.Usecase.Boards.GetAllBoards
+  alias KanbanVisionApi.Usecase.Boards.GetBoardById
+  alias KanbanVisionApi.Usecase.Boards.GetBoardsBySimulationId
+  alias KanbanVisionApi.Usecase.RepositoryConfig
+
+  def start_link(opts \\ []) do
+    opts = Keyword.put_new(opts, :repository, RepositoryConfig.fetch!(:board))
+    GenServer.start_link(__MODULE__, opts, Keyword.take(opts, [:name]))
+  end
+
+  def get_all(pid, opts \\ []), do: GenServer.call(pid, {:get_all, opts})
+
+  def get_by_id(pid, %GetBoardByIdQuery{} = query, opts \\ []) do
+    GenServer.call(pid, {:get_by_id, query, opts})
+  end
+
+  def get_by_simulation_id(pid, %GetBoardsBySimulationIdQuery{} = query, opts \\ []) do
+    GenServer.call(pid, {:get_by_simulation_id, query, opts})
+  end
+
+  def add(pid, %CreateBoardCommand{} = cmd, opts \\ []) do
+    GenServer.call(pid, {:add, cmd, opts})
+  end
+
+  def delete(pid, %DeleteBoardCommand{} = cmd, opts \\ []) do
+    GenServer.call(pid, {:delete, cmd, opts})
+  end
+
+  @impl true
+  def init(opts) do
+    repository = Keyword.fetch!(opts, :repository)
+    {:ok, repository_pid} = repository.start_link()
+    repository_runtime = repository.runtime(repository_pid)
+    {:ok, %{repository_runtime: repository_runtime, repository: repository}}
+  end
+
+  @impl true
+  def handle_call({:get_all, opts}, _from, state) do
+    result = GetAllBoards.execute(state.repository_runtime, enrich_opts(opts, state))
+    {:reply, result, state}
+  end
+
+  @impl true
+  def handle_call({:get_by_id, query, opts}, _from, state) do
+    result = GetBoardById.execute(query, state.repository_runtime, enrich_opts(opts, state))
+    {:reply, result, state}
+  end
+
+  @impl true
+  def handle_call({:get_by_simulation_id, query, opts}, _from, state) do
+    result =
+      GetBoardsBySimulationId.execute(
+        query,
+        state.repository_runtime,
+        enrich_opts(opts, state)
+      )
+
+    {:reply, result, state}
+  end
+
+  @impl true
+  def handle_call({:add, cmd, opts}, _from, state) do
+    result = CreateBoard.execute(cmd, state.repository_runtime, enrich_opts(opts, state))
+    {:reply, result, state}
+  end
+
+  @impl true
+  def handle_call({:delete, cmd, opts}, _from, state) do
+    result = DeleteBoard.execute(cmd, state.repository_runtime, enrich_opts(opts, state))
+    {:reply, result, state}
+  end
+
+  defp enrich_opts(opts, state) do
+    Keyword.put_new(opts, :repository, state.repository)
+  end
+end

--- a/apps/usecase/lib/kanban_vision_api/usecase/board/commands.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/board/commands.ex
@@ -1,3 +1,34 @@
+defmodule KanbanVisionApi.Usecase.Board.CreateBoardCommand do
+  @moduledoc """
+  Command: Create a new board.
+
+  Validates input before command creation.
+  """
+
+  @enforce_keys [:name, :simulation_id]
+  defstruct [:name, :simulation_id]
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          simulation_id: String.t()
+        }
+
+  @spec new(String.t(), String.t()) :: {:ok, t()} | {:error, atom()}
+  def new(name, simulation_id)
+      when is_binary(name) and byte_size(name) > 0 and
+             is_binary(simulation_id) and byte_size(simulation_id) > 0 do
+    {:ok, %__MODULE__{name: name, simulation_id: simulation_id}}
+  end
+
+  def new(name, _simulation_id) when not is_binary(name) or byte_size(name) == 0 do
+    {:error, :invalid_name}
+  end
+
+  def new(_name, _simulation_id) do
+    {:error, :invalid_simulation_id}
+  end
+end
+
 defmodule KanbanVisionApi.Usecase.Board.DeleteBoardCommand do
   @moduledoc """
   Command: Delete a board.

--- a/apps/usecase/lib/kanban_vision_api/usecase/board/queries.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/board/queries.ex
@@ -1,0 +1,47 @@
+defmodule KanbanVisionApi.Usecase.Board.GetBoardByIdQuery do
+  @moduledoc """
+  Query: Get board by ID.
+
+  Validates input before query creation.
+  """
+
+  @enforce_keys [:id]
+  defstruct [:id]
+
+  @type t :: %__MODULE__{
+          id: String.t()
+        }
+
+  @spec new(String.t()) :: {:ok, t()} | {:error, atom()}
+  def new(id) when is_binary(id) and byte_size(id) > 0 do
+    {:ok, %__MODULE__{id: id}}
+  end
+
+  def new(_id) do
+    {:error, :invalid_id}
+  end
+end
+
+defmodule KanbanVisionApi.Usecase.Board.GetBoardsBySimulationIdQuery do
+  @moduledoc """
+  Query: Get boards by simulation ID.
+
+  Validates input before query creation.
+  """
+
+  @enforce_keys [:simulation_id]
+  defstruct [:simulation_id]
+
+  @type t :: %__MODULE__{
+          simulation_id: String.t()
+        }
+
+  @spec new(String.t()) :: {:ok, t()} | {:error, atom()}
+  def new(simulation_id) when is_binary(simulation_id) and byte_size(simulation_id) > 0 do
+    {:ok, %__MODULE__{simulation_id: simulation_id}}
+  end
+
+  def new(_simulation_id) do
+    {:error, :invalid_simulation_id}
+  end
+end

--- a/apps/usecase/lib/kanban_vision_api/usecase/boards/create_board.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/boards/create_board.ex
@@ -1,0 +1,69 @@
+defmodule KanbanVisionApi.Usecase.Boards.CreateBoard do
+  @moduledoc """
+  Use Case: Create a new board.
+
+  Orchestrates board creation, logging, and event emission.
+  """
+
+  require Logger
+
+  alias KanbanVisionApi.Domain.Board
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
+  alias KanbanVisionApi.Domain.Ports.BoardRepository
+  alias KanbanVisionApi.Usecase.Board.CreateBoardCommand
+  alias KanbanVisionApi.Usecase.ErrorMetadata
+  alias KanbanVisionApi.Usecase.EventEmitter
+  alias KanbanVisionApi.Usecase.RepositoryConfig
+
+  @type result :: ApplicationError.result(Board.t())
+
+  @spec execute(CreateBoardCommand.t(), BoardRepository.repository_runtime(), keyword()) ::
+          result()
+  def execute(%CreateBoardCommand{} = cmd, repository_runtime, opts \\ []) do
+    correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
+    repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
+
+    Logger.info("Creating board",
+      correlation_id: correlation_id,
+      board_name: cmd.name,
+      simulation_id: cmd.simulation_id
+    )
+
+    board = Board.new(cmd.name, cmd.simulation_id)
+
+    case repository.add(repository_runtime, board) do
+      {:ok, created_board} ->
+        Logger.info("Board created successfully",
+          correlation_id: correlation_id,
+          board_id: created_board.id,
+          board_name: created_board.name,
+          simulation_id: created_board.simulation_id
+        )
+
+        EventEmitter.emit(
+          :board,
+          :board_created,
+          %{
+            board_id: created_board.id,
+            board_name: created_board.name,
+            simulation_id: created_board.simulation_id
+          },
+          correlation_id
+        )
+
+        {:ok, created_board}
+
+      {:error, reason} = error ->
+        metadata =
+          [
+            correlation_id: correlation_id,
+            board_name: cmd.name,
+            simulation_id: cmd.simulation_id
+          ] ++ ErrorMetadata.from_reason(reason)
+
+        Logger.error("Failed to create board", metadata)
+
+        error
+    end
+  end
+end

--- a/apps/usecase/lib/kanban_vision_api/usecase/boards/get_all_boards.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/boards/get_all_boards.ex
@@ -1,0 +1,39 @@
+defmodule KanbanVisionApi.Usecase.Boards.GetAllBoards do
+  @moduledoc """
+  Use Case: Retrieve all boards.
+
+  Query operation with logging for observability.
+  """
+
+  require Logger
+
+  alias KanbanVisionApi.Domain.Ports.BoardRepository
+  alias KanbanVisionApi.Usecase.EventEmitter
+  alias KanbanVisionApi.Usecase.RepositoryConfig
+
+  @type result :: {:ok, map()}
+
+  @spec execute(BoardRepository.repository_runtime(), keyword()) :: result()
+  def execute(repository_runtime, opts \\ []) do
+    correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
+    repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
+
+    Logger.debug("Retrieving all boards", correlation_id: correlation_id)
+
+    boards = repository.get_all(repository_runtime)
+
+    Logger.debug("All boards retrieved",
+      correlation_id: correlation_id,
+      count: map_size(boards)
+    )
+
+    EventEmitter.emit(
+      :board,
+      :all_boards_retrieved,
+      %{count: map_size(boards)},
+      correlation_id
+    )
+
+    {:ok, boards}
+  end
+end

--- a/apps/usecase/lib/kanban_vision_api/usecase/boards/get_board_by_id.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/boards/get_board_by_id.ex
@@ -1,0 +1,50 @@
+defmodule KanbanVisionApi.Usecase.Boards.GetBoardById do
+  @moduledoc """
+  Use Case: Retrieve a board by its ID.
+
+  Query operation with logging for observability.
+  """
+
+  require Logger
+
+  alias KanbanVisionApi.Domain.Board
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
+  alias KanbanVisionApi.Domain.Ports.BoardRepository
+  alias KanbanVisionApi.Usecase.Board.GetBoardByIdQuery
+  alias KanbanVisionApi.Usecase.ErrorMetadata
+  alias KanbanVisionApi.Usecase.RepositoryConfig
+
+  @type result :: ApplicationError.result(Board.t())
+
+  @spec execute(GetBoardByIdQuery.t(), BoardRepository.repository_runtime(), keyword()) ::
+          result()
+  def execute(%GetBoardByIdQuery{} = query, repository_runtime, opts \\ []) do
+    correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
+    repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
+
+    Logger.debug("Retrieving board by ID",
+      correlation_id: correlation_id,
+      board_id: query.id
+    )
+
+    result = repository.get_by_id(repository_runtime, query.id)
+
+    case result do
+      {:ok, board} ->
+        Logger.debug("Board retrieved successfully",
+          correlation_id: correlation_id,
+          board_id: board.id,
+          simulation_id: board.simulation_id
+        )
+
+      {:error, reason} ->
+        metadata =
+          [correlation_id: correlation_id, board_id: query.id] ++
+            ErrorMetadata.from_reason(reason)
+
+        Logger.warning("Board not found", metadata)
+    end
+
+    result
+  end
+end

--- a/apps/usecase/lib/kanban_vision_api/usecase/boards/get_boards_by_simulation_id.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/boards/get_boards_by_simulation_id.ex
@@ -1,0 +1,61 @@
+defmodule KanbanVisionApi.Usecase.Boards.GetBoardsBySimulationId do
+  @moduledoc """
+  Use Case: Retrieve boards by simulation ID.
+
+  Query operation with logging for observability.
+  """
+
+  require Logger
+
+  alias KanbanVisionApi.Domain.Board
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
+  alias KanbanVisionApi.Domain.Ports.BoardRepository
+  alias KanbanVisionApi.Usecase.Board.GetBoardsBySimulationIdQuery
+  alias KanbanVisionApi.Usecase.ErrorMetadata
+  alias KanbanVisionApi.Usecase.EventEmitter
+  alias KanbanVisionApi.Usecase.RepositoryConfig
+
+  @type result :: ApplicationError.result([Board.t()])
+
+  @spec execute(
+          GetBoardsBySimulationIdQuery.t(),
+          BoardRepository.repository_runtime(),
+          keyword()
+        ) :: result()
+  def execute(%GetBoardsBySimulationIdQuery{} = query, repository_runtime, opts \\ []) do
+    correlation_id = Keyword.get(opts, :correlation_id, UUID.uuid4())
+    repository = RepositoryConfig.fetch_from_opts!(__MODULE__, opts)
+
+    Logger.debug("Retrieving boards by simulation ID",
+      correlation_id: correlation_id,
+      simulation_id: query.simulation_id
+    )
+
+    result = repository.get_all_by_simulation_id(repository_runtime, query.simulation_id)
+
+    case result do
+      {:ok, boards} ->
+        Logger.debug("Boards retrieved successfully",
+          correlation_id: correlation_id,
+          simulation_id: query.simulation_id,
+          count: length(boards)
+        )
+
+        EventEmitter.emit(
+          :board,
+          :boards_by_simulation_retrieved,
+          %{simulation_id: query.simulation_id, count: length(boards)},
+          correlation_id
+        )
+
+      {:error, reason} ->
+        metadata =
+          [correlation_id: correlation_id, simulation_id: query.simulation_id] ++
+            ErrorMetadata.from_reason(reason)
+
+        Logger.warning("Boards not found", metadata)
+    end
+
+    result
+  end
+end

--- a/apps/usecase/lib/kanban_vision_api/usecase/repository_config.ex
+++ b/apps/usecase/lib/kanban_vision_api/usecase/repository_config.ex
@@ -7,10 +7,10 @@ defmodule KanbanVisionApi.Usecase.RepositoryConfig do
   persistence modules.
   """
 
-  @type repository_key :: :organization | :simulation
+  @type repository_key :: :organization | :simulation | :board
 
   @spec fetch!(repository_key()) :: module()
-  def fetch!(key) when key in [:organization, :simulation] do
+  def fetch!(key) when key in [:organization, :simulation, :board] do
     repositories =
       Application.get_env(:usecase, :repositories, [])
 

--- a/apps/usecase/test/kanban_vision_api/usecase/board_test.exs
+++ b/apps/usecase/test/kanban_vision_api/usecase/board_test.exs
@@ -74,7 +74,7 @@ defmodule KanbanVisionApi.Usecase.BoardTest do
 
       assert Board.add(pid, duplicate_cmd) ==
                ApplicationError.conflict(
-                 "Board with name: Dev Board from simulation_id: sim-123 already exist",
+                 "Board with name: Dev Board from simulation_id: sim-123 already exists",
                  %{entity: :board, field: :name, name: "Dev Board", simulation_id: "sim-123"}
                )
     end

--- a/apps/usecase/test/kanban_vision_api/usecase/board_test.exs
+++ b/apps/usecase/test/kanban_vision_api/usecase/board_test.exs
@@ -1,0 +1,94 @@
+defmodule KanbanVisionApi.Usecase.BoardTest do
+  use ExUnit.Case, async: true
+
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
+  alias KanbanVisionApi.Usecase.Board
+  alias KanbanVisionApi.Usecase.Board.CreateBoardCommand
+  alias KanbanVisionApi.Usecase.Board.DeleteBoardCommand
+  alias KanbanVisionApi.Usecase.Board.GetBoardByIdQuery
+  alias KanbanVisionApi.Usecase.Board.GetBoardsBySimulationIdQuery
+
+  describe "When start with empty state" do
+    setup [:start_usecase]
+
+    test "should return empty map", %{pid: pid} do
+      assert Board.get_all(pid) == {:ok, %{}}
+    end
+
+    test "should add a new board via command", %{pid: pid} do
+      {:ok, cmd} = CreateBoardCommand.new("Dev Board", "sim-123")
+      assert {:ok, board} = Board.add(pid, cmd)
+      assert board.name == "Dev Board"
+      assert board.simulation_id == "sim-123"
+    end
+
+    test "should find board by id via query", %{pid: pid} do
+      {:ok, cmd} = CreateBoardCommand.new("Dev Board", "sim-123")
+      {:ok, board} = Board.add(pid, cmd)
+
+      {:ok, query} = GetBoardByIdQuery.new(board.id)
+      assert {:ok, ^board} = Board.get_by_id(pid, query)
+    end
+
+    test "should find boards by simulation id via query", %{pid: pid} do
+      {:ok, cmd} = CreateBoardCommand.new("Dev Board", "sim-123")
+      {:ok, board} = Board.add(pid, cmd)
+
+      {:ok, query} = GetBoardsBySimulationIdQuery.new("sim-123")
+      assert {:ok, [^board]} = Board.get_by_simulation_id(pid, query)
+    end
+
+    test "should delete a board via command", %{pid: pid} do
+      {:ok, cmd} = CreateBoardCommand.new("Dev Board", "sim-123")
+      {:ok, board} = Board.add(pid, cmd)
+
+      {:ok, delete_cmd} = DeleteBoardCommand.new(board.id)
+      assert {:ok, ^board} = Board.delete(pid, delete_cmd)
+    end
+
+    test "should return error for non-existent id", %{pid: pid} do
+      {:ok, query} = GetBoardByIdQuery.new("invalid")
+
+      assert Board.get_by_id(pid, query) ==
+               ApplicationError.not_found(
+                 "Board with id: invalid not found",
+                 %{entity: :board, id: "invalid"}
+               )
+    end
+
+    test "should return error for non-existent simulation id", %{pid: pid} do
+      {:ok, query} = GetBoardsBySimulationIdQuery.new("sim-999")
+
+      assert Board.get_by_simulation_id(pid, query) ==
+               ApplicationError.not_found(
+                 "Boards by simulation_id: sim-999 not found",
+                 %{entity: :board, field: :simulation_id, simulation_id: "sim-999"}
+               )
+    end
+
+    test "should not allow duplicate board names in the same simulation", %{pid: pid} do
+      {:ok, cmd} = CreateBoardCommand.new("Dev Board", "sim-123")
+      {:ok, _} = Board.add(pid, cmd)
+
+      {:ok, duplicate_cmd} = CreateBoardCommand.new("Dev Board", "sim-123")
+
+      assert Board.add(pid, duplicate_cmd) ==
+               ApplicationError.conflict(
+                 "Board with name: Dev Board from simulation_id: sim-123 already exist",
+                 %{entity: :board, field: :name, name: "Dev Board", simulation_id: "sim-123"}
+               )
+    end
+
+    test "should reject invalid command", %{pid: _pid} do
+      assert {:error, :invalid_name} = CreateBoardCommand.new("", "sim-123")
+      assert {:error, :invalid_simulation_id} = CreateBoardCommand.new("Dev Board", "")
+      assert {:error, :invalid_id} = GetBoardByIdQuery.new("")
+      assert {:error, :invalid_simulation_id} = GetBoardsBySimulationIdQuery.new("")
+    end
+  end
+
+  defp start_usecase(_context) do
+    {:ok, pid} = Board.start_link()
+    [pid: pid]
+  end
+end

--- a/apps/usecase/test/kanban_vision_api/usecase/repository_config_test.exs
+++ b/apps/usecase/test/kanban_vision_api/usecase/repository_config_test.exs
@@ -1,6 +1,7 @@
 defmodule KanbanVisionApi.Usecase.RepositoryConfigTest do
   use ExUnit.Case, async: true
 
+  alias KanbanVisionApi.Agent.Boards
   alias KanbanVisionApi.Agent.Organizations
   alias KanbanVisionApi.Usecase.RepositoryConfig
 
@@ -19,6 +20,22 @@ defmodule KanbanVisionApi.Usecase.RepositoryConfigTest do
       end)
 
       assert RepositoryConfig.fetch!(:organization) == Organizations
+    end
+
+    test "returns the configured board repository module" do
+      original = Application.get_env(:usecase, :repositories)
+
+      Application.put_env(:usecase, :repositories, board: Boards)
+
+      on_exit(fn ->
+        if original do
+          Application.put_env(:usecase, :repositories, original)
+        else
+          Application.delete_env(:usecase, :repositories)
+        end
+      end)
+
+      assert RepositoryConfig.fetch!(:board) == Boards
     end
   end
 

--- a/apps/web_api/lib/kanban_vision_api/web_api/adapters/board_adapter.ex
+++ b/apps/web_api/lib/kanban_vision_api/web_api/adapters/board_adapter.ex
@@ -1,0 +1,22 @@
+defmodule KanbanVisionApi.WebApi.Adapters.BoardAdapter do
+  @moduledoc """
+  Adapter: bridges the BoardUsecase port to the board application boundary.
+  """
+
+  @behaviour KanbanVisionApi.WebApi.Ports.BoardUsecase
+
+  alias KanbanVisionApi.Usecase.Board, as: BoardUsecase
+
+  @impl true
+  def get_by_id(query, opts), do: BoardUsecase.get_by_id(BoardUsecase, query, opts)
+
+  @impl true
+  def get_by_simulation_id(query, opts),
+    do: BoardUsecase.get_by_simulation_id(BoardUsecase, query, opts)
+
+  @impl true
+  def add(cmd, opts), do: BoardUsecase.add(BoardUsecase, cmd, opts)
+
+  @impl true
+  def delete(cmd, opts), do: BoardUsecase.delete(BoardUsecase, cmd, opts)
+end

--- a/apps/web_api/lib/kanban_vision_api/web_api/boards/board_controller.ex
+++ b/apps/web_api/lib/kanban_vision_api/web_api/boards/board_controller.ex
@@ -1,0 +1,81 @@
+defmodule KanbanVisionApi.WebApi.Boards.BoardController do
+  @moduledoc """
+  HTTP adapter: translates HTTP requests to Board use case calls.
+  """
+
+  import Plug.Conn
+
+  alias KanbanVisionApi.Usecase.Board.CreateBoardCommand
+  alias KanbanVisionApi.Usecase.Board.DeleteBoardCommand
+  alias KanbanVisionApi.Usecase.Board.GetBoardByIdQuery
+  alias KanbanVisionApi.Usecase.Board.GetBoardsBySimulationIdQuery
+  alias KanbanVisionApi.WebApi.Boards.BoardSerializer
+  alias KanbanVisionApi.WebApi.ErrorMapper
+
+  @spec call(Plug.Conn.t(), atom()) :: Plug.Conn.t()
+  def call(conn, :get_by_id) do
+    id = conn.path_params["id"]
+
+    with {:ok, query} <- GetBoardByIdQuery.new(id),
+         {:ok, board} <- board_usecase().get_by_id(query, build_opts(conn)) do
+      respond(conn, 200, BoardSerializer.serialize(board))
+    else
+      {:error, reason} -> respond_error(conn, reason)
+    end
+  end
+
+  def call(conn, :get_by_simulation_id) do
+    simulation_id = conn.path_params["simulation_id"]
+
+    with {:ok, query} <- GetBoardsBySimulationIdQuery.new(simulation_id),
+         {:ok, boards} <- board_usecase().get_by_simulation_id(query, build_opts(conn)) do
+      respond(conn, 200, BoardSerializer.serialize_many_list(boards))
+    else
+      {:error, reason} -> respond_error(conn, reason)
+    end
+  end
+
+  def call(conn, :create) do
+    name = conn.body_params["name"]
+    simulation_id = conn.path_params["simulation_id"]
+
+    with {:ok, cmd} <- CreateBoardCommand.new(name, simulation_id),
+         {:ok, board} <- board_usecase().add(cmd, build_opts(conn)) do
+      respond(conn, 201, BoardSerializer.serialize(board))
+    else
+      {:error, reason} -> respond_error(conn, reason)
+    end
+  end
+
+  def call(conn, :delete) do
+    id = conn.path_params["id"]
+
+    with {:ok, cmd} <- DeleteBoardCommand.new(id),
+         {:ok, board} <- board_usecase().delete(cmd, build_opts(conn)) do
+      respond(conn, 200, BoardSerializer.serialize(board))
+    else
+      {:error, reason} -> respond_error(conn, reason)
+    end
+  end
+
+  defp board_usecase do
+    Application.get_env(
+      :web_api,
+      :board_usecase,
+      KanbanVisionApi.WebApi.Adapters.BoardAdapter
+    )
+  end
+
+  defp build_opts(conn), do: [correlation_id: conn.assigns[:correlation_id]]
+
+  defp respond(conn, status, data) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(status, Jason.encode!(data))
+  end
+
+  defp respond_error(conn, reason) do
+    error = ErrorMapper.normalize(reason)
+    respond(conn, ErrorMapper.http_status(error), %{error: error.message})
+  end
+end

--- a/apps/web_api/lib/kanban_vision_api/web_api/boards/board_serializer.ex
+++ b/apps/web_api/lib/kanban_vision_api/web_api/boards/board_serializer.ex
@@ -1,0 +1,23 @@
+defmodule KanbanVisionApi.WebApi.Boards.BoardSerializer do
+  @moduledoc """
+  Serializer: converts Domain.Board structs to JSON-safe maps.
+  """
+
+  alias KanbanVisionApi.Domain.Board
+
+  @spec serialize(Board.t()) :: map()
+  def serialize(%Board{} = board) do
+    %{
+      id: board.id,
+      name: board.name,
+      simulation_id: board.simulation_id,
+      created_at: DateTime.to_iso8601(board.audit.created),
+      updated_at: DateTime.to_iso8601(board.audit.updated)
+    }
+  end
+
+  @spec serialize_many_list(list()) :: list(map())
+  def serialize_many_list(boards) when is_list(boards) do
+    Enum.map(boards, &serialize/1)
+  end
+end

--- a/apps/web_api/lib/kanban_vision_api/web_api/error_mapper.ex
+++ b/apps/web_api/lib/kanban_vision_api/web_api/error_mapper.ex
@@ -23,6 +23,14 @@ defmodule KanbanVisionApi.WebApi.ErrorMapper do
     )
   end
 
+  def normalize(:invalid_simulation_id) do
+    ApplicationError.new(
+      :invalid_input,
+      "Invalid simulation ID",
+      %{reason: :invalid_simulation_id}
+    )
+  end
+
   def normalize(reason) when is_binary(reason) do
     ApplicationError.new(:internal_error, reason, %{legacy_reason: :binary})
   end

--- a/apps/web_api/lib/kanban_vision_api/web_api/open_api/schemas/board_schema.ex
+++ b/apps/web_api/lib/kanban_vision_api/web_api/open_api/schemas/board_schema.ex
@@ -1,0 +1,19 @@
+defmodule KanbanVisionApi.WebApi.OpenApi.Schemas.BoardSchema do
+  @moduledoc false
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "Board",
+    description: "Board representation",
+    type: :object,
+    properties: %{
+      id: %OpenApiSpex.Schema{type: :string},
+      name: %OpenApiSpex.Schema{type: :string},
+      simulation_id: %OpenApiSpex.Schema{type: :string},
+      created_at: %OpenApiSpex.Schema{type: :string, format: :"date-time"},
+      updated_at: %OpenApiSpex.Schema{type: :string, format: :"date-time"}
+    },
+    required: [:id, :name, :simulation_id, :created_at, :updated_at]
+  })
+end

--- a/apps/web_api/lib/kanban_vision_api/web_api/open_api/spec.ex
+++ b/apps/web_api/lib/kanban_vision_api/web_api/open_api/spec.ex
@@ -7,6 +7,7 @@ defmodule KanbanVisionApi.WebApi.OpenApi.Spec do
 
   @behaviour OpenApiSpex.OpenApi
 
+  alias KanbanVisionApi.WebApi.OpenApi.Schemas.BoardSchema
   alias KanbanVisionApi.WebApi.OpenApi.Schemas.ErrorSchema
   alias KanbanVisionApi.WebApi.OpenApi.Schemas.OrganizationSchema
   alias KanbanVisionApi.WebApi.OpenApi.Schemas.SimulationSchema
@@ -26,6 +27,7 @@ defmodule KanbanVisionApi.WebApi.OpenApi.Spec do
       paths: paths(),
       components: %OpenApiSpex.Components{
         schemas: %{
+          "Board" => BoardSchema.schema(),
           "Organization" => OrganizationSchema.schema(),
           "Simulation" => SimulationSchema.schema(),
           "Error" => ErrorSchema.schema()
@@ -34,6 +36,7 @@ defmodule KanbanVisionApi.WebApi.OpenApi.Spec do
     }
   end
 
+  defp board_ref, do: %OpenApiSpex.Reference{"$ref": "#/components/schemas/Board"}
   defp org_ref, do: %OpenApiSpex.Reference{"$ref": "#/components/schemas/Organization"}
   defp sim_ref, do: %OpenApiSpex.Reference{"$ref": "#/components/schemas/Simulation"}
   defp error_ref, do: %OpenApiSpex.Reference{"$ref": "#/components/schemas/Error"}
@@ -44,6 +47,10 @@ defmodule KanbanVisionApi.WebApi.OpenApi.Spec do
 
   defp sim_list_schema do
     %OpenApiSpex.Schema{type: :array, items: sim_ref()}
+  end
+
+  defp board_list_schema do
+    %OpenApiSpex.Schema{type: :array, items: board_ref()}
   end
 
   defp json_content(schema) do
@@ -279,6 +286,127 @@ defmodule KanbanVisionApi.WebApi.OpenApi.Spec do
             200 => %OpenApiSpex.Response{
               description: "Deleted simulation",
               content: json_content(sim_ref())
+            },
+            404 => %OpenApiSpex.Response{
+              description: "Not found",
+              content: json_content(error_ref())
+            },
+            422 => %OpenApiSpex.Response{
+              description: "Validation error",
+              content: json_content(error_ref())
+            }
+          }
+        }
+      },
+      "/api/v1/simulations/{simulation_id}/boards" => %OpenApiSpex.PathItem{
+        get: %OpenApiSpex.Operation{
+          summary: "List boards by simulation ID",
+          operationId: "listBoardsBySimulationId",
+          tags: ["Boards"],
+          parameters: [
+            %OpenApiSpex.Parameter{
+              name: :simulation_id,
+              in: :path,
+              required: true,
+              schema: %OpenApiSpex.Schema{type: :string}
+            }
+          ],
+          responses: %{
+            200 => %OpenApiSpex.Response{
+              description: "Boards for the simulation",
+              content: json_content(board_list_schema())
+            },
+            404 => %OpenApiSpex.Response{
+              description: "Not found",
+              content: json_content(error_ref())
+            },
+            422 => %OpenApiSpex.Response{
+              description: "Validation error",
+              content: json_content(error_ref())
+            }
+          }
+        },
+        post: %OpenApiSpex.Operation{
+          summary: "Create a board in a simulation",
+          operationId: "createBoard",
+          tags: ["Boards"],
+          parameters: [
+            %OpenApiSpex.Parameter{
+              name: :simulation_id,
+              in: :path,
+              required: true,
+              schema: %OpenApiSpex.Schema{type: :string}
+            }
+          ],
+          requestBody: %OpenApiSpex.RequestBody{
+            required: true,
+            content:
+              json_content(%OpenApiSpex.Schema{
+                type: :object,
+                properties: %{name: %OpenApiSpex.Schema{type: :string}},
+                required: [:name]
+              })
+          },
+          responses: %{
+            201 => %OpenApiSpex.Response{
+              description: "Board created",
+              content: json_content(board_ref())
+            },
+            409 => %OpenApiSpex.Response{
+              description: "Already exists",
+              content: json_content(error_ref())
+            },
+            422 => %OpenApiSpex.Response{
+              description: "Validation error",
+              content: json_content(error_ref())
+            }
+          }
+        }
+      },
+      "/api/v1/boards/{id}" => %OpenApiSpex.PathItem{
+        get: %OpenApiSpex.Operation{
+          summary: "Get board by ID",
+          operationId: "getBoardById",
+          tags: ["Boards"],
+          parameters: [
+            %OpenApiSpex.Parameter{
+              name: :id,
+              in: :path,
+              required: true,
+              schema: %OpenApiSpex.Schema{type: :string}
+            }
+          ],
+          responses: %{
+            200 => %OpenApiSpex.Response{
+              description: "Board",
+              content: json_content(board_ref())
+            },
+            404 => %OpenApiSpex.Response{
+              description: "Not found",
+              content: json_content(error_ref())
+            },
+            422 => %OpenApiSpex.Response{
+              description: "Validation error",
+              content: json_content(error_ref())
+            }
+          }
+        },
+        delete: %OpenApiSpex.Operation{
+          summary: "Delete a board",
+          operationId: "deleteBoard",
+          tags: ["Boards"],
+          parameters: [
+            %OpenApiSpex.Parameter{
+              name: :id,
+              in: :path,
+              required: true,
+              schema: %OpenApiSpex.Schema{type: :string}
+            }
+          ],
+          responses: %{
+            200 => %OpenApiSpex.Response{
+              description: "Deleted board",
+              content: json_content(board_ref())
             },
             404 => %OpenApiSpex.Response{
               description: "Not found",

--- a/apps/web_api/lib/kanban_vision_api/web_api/ports/board_usecase.ex
+++ b/apps/web_api/lib/kanban_vision_api/web_api/ports/board_usecase.ex
@@ -1,0 +1,25 @@
+defmodule KanbanVisionApi.WebApi.Ports.BoardUsecase do
+  @moduledoc """
+  Port: defines the Board use case interface for the web layer.
+  """
+
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
+  alias KanbanVisionApi.Usecase.Board.CreateBoardCommand
+  alias KanbanVisionApi.Usecase.Board.DeleteBoardCommand
+  alias KanbanVisionApi.Usecase.Board.GetBoardByIdQuery
+  alias KanbanVisionApi.Usecase.Board.GetBoardsBySimulationIdQuery
+
+  @type error_reason :: ApplicationError.t() | atom()
+
+  @callback get_by_id(GetBoardByIdQuery.t(), opts :: keyword()) ::
+              {:ok, any()} | {:error, error_reason()}
+
+  @callback get_by_simulation_id(GetBoardsBySimulationIdQuery.t(), opts :: keyword()) ::
+              {:ok, list()} | {:error, error_reason()}
+
+  @callback add(CreateBoardCommand.t(), opts :: keyword()) ::
+              {:ok, any()} | {:error, error_reason()}
+
+  @callback delete(DeleteBoardCommand.t(), opts :: keyword()) ::
+              {:ok, any()} | {:error, error_reason()}
+end

--- a/apps/web_api/lib/kanban_vision_api/web_api/ports/board_usecase.ex
+++ b/apps/web_api/lib/kanban_vision_api/web_api/ports/board_usecase.ex
@@ -3,6 +3,7 @@ defmodule KanbanVisionApi.WebApi.Ports.BoardUsecase do
   Port: defines the Board use case interface for the web layer.
   """
 
+  alias KanbanVisionApi.Domain.Board
   alias KanbanVisionApi.Domain.Ports.ApplicationError
   alias KanbanVisionApi.Usecase.Board.CreateBoardCommand
   alias KanbanVisionApi.Usecase.Board.DeleteBoardCommand
@@ -12,14 +13,14 @@ defmodule KanbanVisionApi.WebApi.Ports.BoardUsecase do
   @type error_reason :: ApplicationError.t() | atom()
 
   @callback get_by_id(GetBoardByIdQuery.t(), opts :: keyword()) ::
-              {:ok, any()} | {:error, error_reason()}
+              {:ok, Board.t()} | {:error, error_reason()}
 
   @callback get_by_simulation_id(GetBoardsBySimulationIdQuery.t(), opts :: keyword()) ::
-              {:ok, list()} | {:error, error_reason()}
+              {:ok, [Board.t()]} | {:error, error_reason()}
 
   @callback add(CreateBoardCommand.t(), opts :: keyword()) ::
-              {:ok, any()} | {:error, error_reason()}
+              {:ok, Board.t()} | {:error, error_reason()}
 
   @callback delete(DeleteBoardCommand.t(), opts :: keyword()) ::
-              {:ok, any()} | {:error, error_reason()}
+              {:ok, Board.t()} | {:error, error_reason()}
 end

--- a/apps/web_api/lib/kanban_vision_api/web_api/router.ex
+++ b/apps/web_api/lib/kanban_vision_api/web_api/router.ex
@@ -8,6 +8,7 @@ defmodule KanbanVisionApi.WebApi.Router do
 
   use Plug.Router
 
+  alias KanbanVisionApi.WebApi.Boards.BoardController
   alias KanbanVisionApi.WebApi.OpenApi.Spec
   alias KanbanVisionApi.WebApi.Organizations.OrganizationController
   alias KanbanVisionApi.WebApi.Plugs.CorrelationId
@@ -80,6 +81,24 @@ defmodule KanbanVisionApi.WebApi.Router do
 
   delete "/api/v1/simulations/:id" do
     SimulationController.call(conn, :delete)
+  end
+
+  # Board routes
+
+  get "/api/v1/simulations/:simulation_id/boards" do
+    BoardController.call(conn, :get_by_simulation_id)
+  end
+
+  post "/api/v1/simulations/:simulation_id/boards" do
+    BoardController.call(conn, :create)
+  end
+
+  get "/api/v1/boards/:id" do
+    BoardController.call(conn, :get_by_id)
+  end
+
+  delete "/api/v1/boards/:id" do
+    BoardController.call(conn, :delete)
   end
 
   match _ do

--- a/apps/web_api/test/kanban_vision_api/web_api/boards/board_controller_test.exs
+++ b/apps/web_api/test/kanban_vision_api/web_api/boards/board_controller_test.exs
@@ -128,7 +128,7 @@ defmodule KanbanVisionApi.WebApi.Boards.BoardControllerTest do
     test "returns 409 when board already exists", %{board: board} do
       expect(BoardUsecaseMock, :add, fn _cmd, _opts ->
         ApplicationError.conflict(
-          "Board with name: #{board.name} from simulation_id: #{board.simulation_id} already exist",
+          "Board with name: #{board.name} from simulation_id: #{board.simulation_id} already exists",
           %{}
         )
       end)

--- a/apps/web_api/test/kanban_vision_api/web_api/boards/board_controller_test.exs
+++ b/apps/web_api/test/kanban_vision_api/web_api/boards/board_controller_test.exs
@@ -1,0 +1,178 @@
+defmodule KanbanVisionApi.WebApi.Boards.BoardControllerTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+  import Plug.Conn
+  import Plug.Test
+
+  alias KanbanVisionApi.Domain.Board
+  alias KanbanVisionApi.Domain.Ports.ApplicationError
+  alias KanbanVisionApi.WebApi.Boards.BoardController
+  alias KanbanVisionApi.WebApi.BoardUsecaseMock
+
+  setup :verify_on_exit!
+
+  setup do
+    Application.put_env(:web_api, :board_usecase, BoardUsecaseMock)
+    on_exit(fn -> Application.delete_env(:web_api, :board_usecase) end)
+    board = Board.new("Dev Board", "sim-123")
+    %{board: board}
+  end
+
+  describe "call/2 :get_by_simulation_id" do
+    test "returns 200 with matching boards", %{board: board} do
+      expect(BoardUsecaseMock, :get_by_simulation_id, fn _query, _opts ->
+        {:ok, [board]}
+      end)
+
+      conn =
+        :get
+        |> conn("/api/v1/simulations/sim-123/boards")
+        |> Plug.Conn.assign(:correlation_id, "test-id")
+        |> Map.put(:path_params, %{"simulation_id" => "sim-123"})
+        |> BoardController.call(:get_by_simulation_id)
+
+      assert conn.status == 200
+      body = Jason.decode!(conn.resp_body)
+      assert length(body) == 1
+      assert hd(body)["name"] == "Dev Board"
+    end
+
+    test "returns 422 when simulation id is missing" do
+      conn =
+        :get
+        |> conn("/api/v1/simulations//boards")
+        |> Plug.Conn.assign(:correlation_id, "test-id")
+        |> Map.put(:path_params, %{"simulation_id" => ""})
+        |> BoardController.call(:get_by_simulation_id)
+
+      assert conn.status == 422
+    end
+
+    test "returns 404 when no boards are found" do
+      expect(BoardUsecaseMock, :get_by_simulation_id, fn _query, _opts ->
+        ApplicationError.not_found("Boards by simulation_id: sim-404 not found", %{})
+      end)
+
+      conn =
+        :get
+        |> conn("/api/v1/simulations/sim-404/boards")
+        |> Plug.Conn.assign(:correlation_id, "test-id")
+        |> Map.put(:path_params, %{"simulation_id" => "sim-404"})
+        |> BoardController.call(:get_by_simulation_id)
+
+      assert conn.status == 404
+    end
+  end
+
+  describe "call/2 :get_by_id" do
+    test "returns 200 with board", %{board: board} do
+      expect(BoardUsecaseMock, :get_by_id, fn _query, _opts -> {:ok, board} end)
+
+      conn =
+        :get
+        |> conn("/api/v1/boards/#{board.id}")
+        |> Plug.Conn.assign(:correlation_id, "test-id")
+        |> Map.put(:path_params, %{"id" => board.id})
+        |> BoardController.call(:get_by_id)
+
+      assert conn.status == 200
+      assert Jason.decode!(conn.resp_body)["name"] == "Dev Board"
+    end
+
+    test "returns 404 when board not found", %{board: board} do
+      expect(BoardUsecaseMock, :get_by_id, fn _query, _opts ->
+        ApplicationError.not_found("Board with id: #{board.id} not found", %{})
+      end)
+
+      conn =
+        :get
+        |> conn("/api/v1/boards/#{board.id}")
+        |> Plug.Conn.assign(:correlation_id, "test-id")
+        |> Map.put(:path_params, %{"id" => board.id})
+        |> BoardController.call(:get_by_id)
+
+      assert conn.status == 404
+    end
+  end
+
+  describe "call/2 :create" do
+    test "returns 201 with created board", %{board: board} do
+      expect(BoardUsecaseMock, :add, fn _cmd, _opts -> {:ok, board} end)
+
+      conn =
+        :post
+        |> conn("/api/v1/simulations/sim-123/boards", Jason.encode!(%{name: "Dev Board"}))
+        |> put_req_header("content-type", "application/json")
+        |> Plug.Conn.assign(:correlation_id, "test-id")
+        |> Map.put(:path_params, %{"simulation_id" => "sim-123"})
+        |> Map.put(:body_params, %{"name" => "Dev Board"})
+        |> BoardController.call(:create)
+
+      assert conn.status == 201
+      assert Jason.decode!(conn.resp_body)["name"] == "Dev Board"
+    end
+
+    test "returns 422 when name is missing" do
+      conn =
+        :post
+        |> conn("/api/v1/simulations/sim-123/boards")
+        |> Plug.Conn.assign(:correlation_id, "test-id")
+        |> Map.put(:path_params, %{"simulation_id" => "sim-123"})
+        |> Map.put(:body_params, %{})
+        |> BoardController.call(:create)
+
+      assert conn.status == 422
+    end
+
+    test "returns 409 when board already exists", %{board: board} do
+      expect(BoardUsecaseMock, :add, fn _cmd, _opts ->
+        ApplicationError.conflict(
+          "Board with name: #{board.name} from simulation_id: #{board.simulation_id} already exist",
+          %{}
+        )
+      end)
+
+      conn =
+        :post
+        |> conn("/api/v1/simulations/sim-123/boards")
+        |> Plug.Conn.assign(:correlation_id, "test-id")
+        |> Map.put(:path_params, %{"simulation_id" => "sim-123"})
+        |> Map.put(:body_params, %{"name" => board.name})
+        |> BoardController.call(:create)
+
+      assert conn.status == 409
+    end
+  end
+
+  describe "call/2 :delete" do
+    test "returns 200 with deleted board", %{board: board} do
+      expect(BoardUsecaseMock, :delete, fn _cmd, _opts -> {:ok, board} end)
+
+      conn =
+        :delete
+        |> conn("/api/v1/boards/#{board.id}")
+        |> Plug.Conn.assign(:correlation_id, "test-id")
+        |> Map.put(:path_params, %{"id" => board.id})
+        |> BoardController.call(:delete)
+
+      assert conn.status == 200
+      assert Jason.decode!(conn.resp_body)["name"] == "Dev Board"
+    end
+
+    test "returns 404 when board not found", %{board: board} do
+      expect(BoardUsecaseMock, :delete, fn _cmd, _opts ->
+        ApplicationError.not_found("Board with id: #{board.id} not found", %{})
+      end)
+
+      conn =
+        :delete
+        |> conn("/api/v1/boards/#{board.id}")
+        |> Plug.Conn.assign(:correlation_id, "test-id")
+        |> Map.put(:path_params, %{"id" => board.id})
+        |> BoardController.call(:delete)
+
+      assert conn.status == 404
+    end
+  end
+end

--- a/apps/web_api/test/kanban_vision_api/web_api/boards/board_serializer_test.exs
+++ b/apps/web_api/test/kanban_vision_api/web_api/boards/board_serializer_test.exs
@@ -1,0 +1,43 @@
+defmodule KanbanVisionApi.WebApi.Boards.BoardSerializerTest do
+  use ExUnit.Case, async: true
+
+  alias KanbanVisionApi.Domain.Board
+  alias KanbanVisionApi.WebApi.Boards.BoardSerializer
+
+  setup do
+    board = Board.new("Dev Board", "sim-123")
+    %{board: board}
+  end
+
+  describe "serialize/1" do
+    test "returns a map with all expected fields", %{board: board} do
+      result = BoardSerializer.serialize(board)
+
+      assert result.id == board.id
+      assert result.name == "Dev Board"
+      assert result.simulation_id == "sim-123"
+      assert is_binary(result.created_at)
+      assert is_binary(result.updated_at)
+    end
+
+    test "formats dates as ISO8601", %{board: board} do
+      result = BoardSerializer.serialize(board)
+
+      assert String.contains?(result.created_at, "T")
+      assert String.contains?(result.updated_at, "T")
+    end
+  end
+
+  describe "serialize_many_list/1" do
+    test "converts a list of boards", %{board: board} do
+      result = BoardSerializer.serialize_many_list([board])
+
+      assert length(result) == 1
+      assert hd(result).name == "Dev Board"
+    end
+
+    test "returns empty list for empty list" do
+      assert BoardSerializer.serialize_many_list([]) == []
+    end
+  end
+end

--- a/apps/web_api/test/kanban_vision_api/web_api/integration/boards_integration_test.exs
+++ b/apps/web_api/test/kanban_vision_api/web_api/integration/boards_integration_test.exs
@@ -1,0 +1,175 @@
+defmodule KanbanVisionApi.WebApi.Integration.BoardsIntegrationTest do
+  @moduledoc """
+  Integration tests for Board HTTP endpoints.
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :integration
+
+  import Plug.Conn
+  import Plug.Test
+
+  alias KanbanVisionApi.WebApi.Router
+
+  @opts Router.init([])
+
+  describe "GET /api/v1/simulations/:simulation_id/boards" do
+    test "returns boards for a simulation" do
+      org = create_organization("BoardOrg")
+      sim = create_simulation("BoardSim", org["id"])
+      board = create_board("Dev Board", sim["id"])
+
+      conn =
+        :get
+        |> conn("/api/v1/simulations/#{sim["id"]}/boards")
+        |> Router.call(@opts)
+
+      assert conn.status == 200
+      body = Jason.decode!(conn.resp_body)
+      assert Enum.any?(body, fn item -> item["id"] == board["id"] end)
+
+      cleanup_board(board["id"])
+      cleanup_simulation(sim["id"])
+      cleanup_organization(org["id"])
+    end
+  end
+
+  describe "POST /api/v1/simulations/:simulation_id/boards" do
+    test "creates a board and returns 201" do
+      org = create_organization("CreateBoardOrg")
+      sim = create_simulation("CreateBoardSim", org["id"])
+
+      conn =
+        :post
+        |> conn("/api/v1/simulations/#{sim["id"]}/boards", Jason.encode!(%{name: "Dev Board"}))
+        |> put_req_header("content-type", "application/json")
+        |> Router.call(@opts)
+
+      assert conn.status == 201
+      body = Jason.decode!(conn.resp_body)
+      assert body["name"] == "Dev Board"
+      assert body["simulation_id"] == sim["id"]
+
+      cleanup_board(body["id"])
+      cleanup_simulation(sim["id"])
+      cleanup_organization(org["id"])
+    end
+
+    test "returns 409 when board already exists" do
+      org = create_organization("ConflictBoardOrg")
+      sim = create_simulation("ConflictBoardSim", org["id"])
+      board = create_board("Dev Board", sim["id"])
+
+      conn =
+        :post
+        |> conn("/api/v1/simulations/#{sim["id"]}/boards", Jason.encode!(%{name: "Dev Board"}))
+        |> put_req_header("content-type", "application/json")
+        |> Router.call(@opts)
+
+      assert conn.status == 409
+      body = Jason.decode!(conn.resp_body)
+      assert is_binary(body["error"])
+      assert body["error"] != ""
+
+      cleanup_board(board["id"])
+      cleanup_simulation(sim["id"])
+      cleanup_organization(org["id"])
+    end
+  end
+
+  describe "GET /api/v1/boards/:id" do
+    test "returns board by id" do
+      org = create_organization("GetBoardOrg")
+      sim = create_simulation("GetBoardSim", org["id"])
+      board = create_board("QA Board", sim["id"])
+
+      conn =
+        :get
+        |> conn("/api/v1/boards/#{board["id"]}")
+        |> Router.call(@opts)
+
+      assert conn.status == 200
+      assert Jason.decode!(conn.resp_body)["name"] == "QA Board"
+
+      cleanup_board(board["id"])
+      cleanup_simulation(sim["id"])
+      cleanup_organization(org["id"])
+    end
+  end
+
+  describe "DELETE /api/v1/boards/:id" do
+    test "deletes a board and returns 200" do
+      org = create_organization("DeleteBoardOrg")
+      sim = create_simulation("DeleteBoardSim", org["id"])
+      board = create_board("Delete Board", sim["id"])
+
+      conn =
+        :delete
+        |> conn("/api/v1/boards/#{board["id"]}")
+        |> Router.call(@opts)
+
+      assert conn.status == 200
+
+      cleanup_simulation(sim["id"])
+      cleanup_organization(org["id"])
+    end
+
+    test "returns 404 for non-existent board" do
+      conn =
+        :delete
+        |> conn("/api/v1/boards/non-existent-id")
+        |> Router.call(@opts)
+
+      assert conn.status == 404
+    end
+  end
+
+  defp create_organization(name) do
+    conn =
+      :post
+      |> conn("/api/v1/organizations", Jason.encode!(%{name: name}))
+      |> put_req_header("content-type", "application/json")
+      |> Router.call(@opts)
+
+    Jason.decode!(conn.resp_body)
+  end
+
+  defp create_simulation(name, org_id) do
+    conn =
+      :post
+      |> conn("/api/v1/simulations", Jason.encode!(%{name: name, organization_id: org_id}))
+      |> put_req_header("content-type", "application/json")
+      |> Router.call(@opts)
+
+    Jason.decode!(conn.resp_body)
+  end
+
+  defp create_board(name, simulation_id) do
+    conn =
+      :post
+      |> conn("/api/v1/simulations/#{simulation_id}/boards", Jason.encode!(%{name: name}))
+      |> put_req_header("content-type", "application/json")
+      |> Router.call(@opts)
+
+    Jason.decode!(conn.resp_body)
+  end
+
+  defp cleanup_board(id) do
+    :delete
+    |> conn("/api/v1/boards/#{id}")
+    |> Router.call(@opts)
+  end
+
+  defp cleanup_simulation(id) do
+    :delete
+    |> conn("/api/v1/simulations/#{id}")
+    |> Router.call(@opts)
+  end
+
+  defp cleanup_organization(id) do
+    :delete
+    |> conn("/api/v1/organizations/#{id}")
+    |> Router.call(@opts)
+  end
+end

--- a/apps/web_api/test/kanban_vision_api/web_api/integration/boards_integration_test.exs
+++ b/apps/web_api/test/kanban_vision_api/web_api/integration/boards_integration_test.exs
@@ -19,6 +19,7 @@ defmodule KanbanVisionApi.WebApi.Integration.BoardsIntegrationTest do
       org = create_organization("BoardOrg")
       sim = create_simulation("BoardSim", org["id"])
       board = create_board("Dev Board", sim["id"])
+      register_cleanup(board_id: board["id"], simulation_id: sim["id"], organization_id: org["id"])
 
       conn =
         :get
@@ -28,10 +29,6 @@ defmodule KanbanVisionApi.WebApi.Integration.BoardsIntegrationTest do
       assert conn.status == 200
       body = Jason.decode!(conn.resp_body)
       assert Enum.any?(body, fn item -> item["id"] == board["id"] end)
-
-      cleanup_board(board["id"])
-      cleanup_simulation(sim["id"])
-      cleanup_organization(org["id"])
     end
   end
 
@@ -39,6 +36,7 @@ defmodule KanbanVisionApi.WebApi.Integration.BoardsIntegrationTest do
     test "creates a board and returns 201" do
       org = create_organization("CreateBoardOrg")
       sim = create_simulation("CreateBoardSim", org["id"])
+      register_cleanup(simulation_id: sim["id"], organization_id: org["id"])
 
       conn =
         :post
@@ -50,16 +48,14 @@ defmodule KanbanVisionApi.WebApi.Integration.BoardsIntegrationTest do
       body = Jason.decode!(conn.resp_body)
       assert body["name"] == "Dev Board"
       assert body["simulation_id"] == sim["id"]
-
-      cleanup_board(body["id"])
-      cleanup_simulation(sim["id"])
-      cleanup_organization(org["id"])
+      register_cleanup(board_id: body["id"])
     end
 
     test "returns 409 when board already exists" do
       org = create_organization("ConflictBoardOrg")
       sim = create_simulation("ConflictBoardSim", org["id"])
       board = create_board("Dev Board", sim["id"])
+      register_cleanup(board_id: board["id"], simulation_id: sim["id"], organization_id: org["id"])
 
       conn =
         :post
@@ -71,10 +67,6 @@ defmodule KanbanVisionApi.WebApi.Integration.BoardsIntegrationTest do
       body = Jason.decode!(conn.resp_body)
       assert is_binary(body["error"])
       assert body["error"] != ""
-
-      cleanup_board(board["id"])
-      cleanup_simulation(sim["id"])
-      cleanup_organization(org["id"])
     end
   end
 
@@ -83,6 +75,7 @@ defmodule KanbanVisionApi.WebApi.Integration.BoardsIntegrationTest do
       org = create_organization("GetBoardOrg")
       sim = create_simulation("GetBoardSim", org["id"])
       board = create_board("QA Board", sim["id"])
+      register_cleanup(board_id: board["id"], simulation_id: sim["id"], organization_id: org["id"])
 
       conn =
         :get
@@ -91,10 +84,6 @@ defmodule KanbanVisionApi.WebApi.Integration.BoardsIntegrationTest do
 
       assert conn.status == 200
       assert Jason.decode!(conn.resp_body)["name"] == "QA Board"
-
-      cleanup_board(board["id"])
-      cleanup_simulation(sim["id"])
-      cleanup_organization(org["id"])
     end
   end
 
@@ -103,6 +92,7 @@ defmodule KanbanVisionApi.WebApi.Integration.BoardsIntegrationTest do
       org = create_organization("DeleteBoardOrg")
       sim = create_simulation("DeleteBoardSim", org["id"])
       board = create_board("Delete Board", sim["id"])
+      register_cleanup(simulation_id: sim["id"], organization_id: org["id"])
 
       conn =
         :delete
@@ -110,9 +100,6 @@ defmodule KanbanVisionApi.WebApi.Integration.BoardsIntegrationTest do
         |> Router.call(@opts)
 
       assert conn.status == 200
-
-      cleanup_simulation(sim["id"])
-      cleanup_organization(org["id"])
     end
 
     test "returns 404 for non-existent board" do
@@ -123,6 +110,22 @@ defmodule KanbanVisionApi.WebApi.Integration.BoardsIntegrationTest do
 
       assert conn.status == 404
     end
+  end
+
+  defp register_cleanup(resources) do
+    on_exit(fn ->
+      if board_id = resources[:board_id] do
+        cleanup_board(board_id)
+      end
+
+      if simulation_id = resources[:simulation_id] do
+        cleanup_simulation(simulation_id)
+      end
+
+      if organization_id = resources[:organization_id] do
+        cleanup_organization(organization_id)
+      end
+    end)
   end
 
   defp create_organization(name) do

--- a/apps/web_api/test/kanban_vision_api/web_api/router_test.exs
+++ b/apps/web_api/test/kanban_vision_api/web_api/router_test.exs
@@ -9,8 +9,10 @@ defmodule KanbanVisionApi.WebApi.RouterTest do
   import Plug.Conn
   import Plug.Test
 
+  alias KanbanVisionApi.Domain.Board
   alias KanbanVisionApi.Domain.Organization
   alias KanbanVisionApi.Domain.Simulation
+  alias KanbanVisionApi.WebApi.BoardUsecaseMock
   alias KanbanVisionApi.WebApi.OrganizationUsecaseMock
   alias KanbanVisionApi.WebApi.Router
   alias KanbanVisionApi.WebApi.SimulationUsecaseMock
@@ -22,15 +24,18 @@ defmodule KanbanVisionApi.WebApi.RouterTest do
   setup do
     Application.put_env(:web_api, :organization_usecase, OrganizationUsecaseMock)
     Application.put_env(:web_api, :simulation_usecase, SimulationUsecaseMock)
+    Application.put_env(:web_api, :board_usecase, BoardUsecaseMock)
 
     on_exit(fn ->
+      Application.delete_env(:web_api, :board_usecase)
       Application.delete_env(:web_api, :organization_usecase)
       Application.delete_env(:web_api, :simulation_usecase)
     end)
 
     org = Organization.new("RouterTestOrg")
     sim = Simulation.new("RouterTestSim", "desc", org.id)
-    %{org: org, sim: sim}
+    board = Board.new("RouterTestBoard", sim.id)
+    %{org: org, sim: sim, board: board}
   end
 
   describe "Organization routes" do
@@ -119,6 +124,49 @@ defmodule KanbanVisionApi.WebApi.RouterTest do
       stub(SimulationUsecaseMock, :delete, fn _cmd, _opts -> {:ok, sim} end)
 
       conn = conn(:delete, "/api/v1/simulations/#{sim.id}") |> Router.call(@opts)
+
+      assert conn.status == 200
+    end
+  end
+
+  describe "Board routes" do
+    test "GET /api/v1/simulations/:simulation_id/boards dispatches to get_by_simulation_id", %{
+      board: board
+    } do
+      stub(BoardUsecaseMock, :get_by_simulation_id, fn _query, _opts -> {:ok, [board]} end)
+
+      conn = conn(:get, "/api/v1/simulations/#{board.simulation_id}/boards") |> Router.call(@opts)
+
+      assert conn.status == 200
+    end
+
+    test "POST /api/v1/simulations/:simulation_id/boards dispatches to create", %{board: board} do
+      stub(BoardUsecaseMock, :add, fn _cmd, _opts -> {:ok, board} end)
+
+      conn =
+        :post
+        |> conn(
+          "/api/v1/simulations/#{board.simulation_id}/boards",
+          Jason.encode!(%{name: "RouterTestBoard"})
+        )
+        |> put_req_header("content-type", "application/json")
+        |> Router.call(@opts)
+
+      assert conn.status == 201
+    end
+
+    test "GET /api/v1/boards/:id dispatches to get_by_id", %{board: board} do
+      stub(BoardUsecaseMock, :get_by_id, fn _query, _opts -> {:ok, board} end)
+
+      conn = conn(:get, "/api/v1/boards/#{board.id}") |> Router.call(@opts)
+
+      assert conn.status == 200
+    end
+
+    test "DELETE /api/v1/boards/:id dispatches to delete", %{board: board} do
+      stub(BoardUsecaseMock, :delete, fn _cmd, _opts -> {:ok, board} end)
+
+      conn = conn(:delete, "/api/v1/boards/#{board.id}") |> Router.call(@opts)
 
       assert conn.status == 200
     end

--- a/apps/web_api/test/test_helper.exs
+++ b/apps/web_api/test/test_helper.exs
@@ -1,5 +1,9 @@
 ExUnit.start(exclude: [:integration])
 
+Mox.defmock(KanbanVisionApi.WebApi.BoardUsecaseMock,
+  for: KanbanVisionApi.WebApi.Ports.BoardUsecase
+)
+
 Mox.defmock(KanbanVisionApi.WebApi.OrganizationUsecaseMock,
   for: KanbanVisionApi.WebApi.Ports.OrganizationUsecase
 )

--- a/config/config.exs
+++ b/config/config.exs
@@ -34,7 +34,8 @@ config :web_api, port: 4000
 config :usecase,
   repositories: [
     organization: KanbanVisionApi.Agent.Organizations,
-    simulation: KanbanVisionApi.Agent.Simulations
+    simulation: KanbanVisionApi.Agent.Simulations,
+    board: KanbanVisionApi.Agent.Boards
   ]
 
 if config_env() == :test do


### PR DESCRIPTION
## Summary
- complete the board context as a first-class bounded context with CQS use cases and a supervised usecase orchestrator
- add board HTTP adapters, routes, serializer, and OpenAPI documentation aligned with the existing hexagonal structure
- register ADR 0004 and add usecase, controller, router, serializer, and integration coverage for board flows

## Validation
- mix format
- mix compile
- mix test
- mix credo --strict
- mix dialyzer
- env MIX_ENV=test mix coveralls --umbrella