### PR TITLE
ci: publish quality reports in pull requests

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -104,7 +104,12 @@ jobs:
       - name: Compile dependencies
         run: mix deps.compile
 
+      - name: Run Dialyzer with GitHub annotations
+        if: github.event_name == 'pull_request'
+        run: mix dialyzer --format github --quiet
+
       - name: Run Dialyzer
+        if: github.event_name != 'pull_request'
         run: mix dialyzer
 
       - name: Write job summary

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -6,9 +6,12 @@ on:
   pull_request:
     branches: ["main"]
 
+concurrency:
+  group: elixir-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
-  pull-requests: write
 
 env:
   ELIXIR_VERSION: "1.18.4"
@@ -228,6 +231,9 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs: [credo, dialyzer, coverage, test]
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: Write workflow summary
@@ -244,7 +250,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Update pull request quality report
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         env:
           CREDO_RESULT: ${{ needs.credo.result }}
@@ -261,6 +267,8 @@ jobs:
                 case 'failure':
                   return '❌'
                 case 'cancelled':
+                  return '⚪'
+                case 'skipped':
                   return '⚪'
                 default:
                   return '🟡'
@@ -285,12 +293,15 @@ jobs:
               `Run: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
             ].join('\n')
 
-            const {data: comments} = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              per_page: 100
-            })
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100
+              }
+            )
 
             const existing = comments.find((comment) => comment.body?.includes(marker))
 

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Run Credo with reviewdog
         if: github.event_name == 'pull_request'
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mix credo suggest --all --strict --format=flycheck --mute-exit-status \
             | reviewdog \

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 env:
   ELIXIR_VERSION: "1.18.4"
@@ -199,3 +200,70 @@ jobs:
             echo "| Coverage | ${{ needs.coverage.result }} |"
             echo "| Test | ${{ needs.test.result }} |"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Update pull request quality report
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          CREDO_RESULT: ${{ needs.credo.result }}
+          DIALYZER_RESULT: ${{ needs.dialyzer.result }}
+          COVERAGE_RESULT: ${{ needs.coverage.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+        with:
+          script: |
+            const marker = '<!-- elixir-ci-report -->'
+            const emojiFor = (result) => {
+              switch (result) {
+                case 'success':
+                  return '✅'
+                case 'failure':
+                  return '❌'
+                case 'cancelled':
+                  return '⚪'
+                default:
+                  return '🟡'
+              }
+            }
+
+            const checks = [
+              ['Credo', process.env.CREDO_RESULT],
+              ['Dialyzer', process.env.DIALYZER_RESULT],
+              ['Coverage', process.env.COVERAGE_RESULT],
+              ['Test', process.env.TEST_RESULT]
+            ]
+
+            const body = [
+              marker,
+              '## Elixir CI Report',
+              '',
+              '| Check | Result |',
+              '| --- | --- |',
+              ...checks.map(([name, result]) => `| ${name} | ${emojiFor(result)} ${result} |`),
+              '',
+              `Run: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            ].join('\n')
+
+            const {data: comments} = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100
+            })
+
+            const existing = comments.find((comment) => comment.body?.includes(marker))
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body
+              })
+            }

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -51,9 +51,28 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mix credo suggest --all --strict --format=flycheck --mute-exit-status \
+          mix credo suggest --all --strict --format=json --mute-exit-status \
+            | jq -c '{
+                source: {name: "credo"},
+                diagnostics: [
+                  .issues[] | {
+                    message: .message,
+                    location: {
+                      path: .filename,
+                      range: {
+                        start: {
+                          line: (.line_no // 1),
+                          column: (.column // 1)
+                        }
+                      }
+                    },
+                    severity: "WARNING",
+                    code: {value: (.check // .category // "Credo")}
+                  }
+                ]
+              }' \
             | reviewdog \
-                -f=flycheck \
+                -f=rdjson \
                 -name=credo \
                 -reporter=github-pr-review \
                 -filter-mode=nofilter \

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -42,7 +42,23 @@ jobs:
       - name: Compile dependencies
         run: mix deps.compile
 
+      - name: Set up reviewdog
+        if: github.event_name == 'pull_request'
+        uses: reviewdog/action-setup@v1
+
+      - name: Run Credo with reviewdog
+        if: github.event_name == 'pull_request'
+        run: |
+          mix credo suggest --all --strict --format=flycheck --mute-exit-status \
+            | reviewdog \
+                -f=flycheck \
+                -name=credo \
+                -reporter=github-pr-review \
+                -filter-mode=nofilter \
+                -fail-level=warning
+
       - name: Run Credo
+        if: github.event_name != 'pull_request'
         run: mix credo
 
       - name: Write job summary


### PR DESCRIPTION
## Summary
- add a sticky PR quality report comment generated from the CI results
- keep the existing separate checks and workflow summary while surfacing the same status inside the pull request
- grant the workflow the pull request permission needed to update the report comment

## Validation
- workflow YAML parsed locally with Ruby Psych ()