### PR TITLE
ci: enable dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## Context

The repo had no `.github/dependabot.yml`, so GitHub was suggesting to enable Dependabot. This adds the config so GitHub opens automated update PRs.

## Change

- New `.github/dependabot.yml` monitoring the **github-actions** ecosystem.
- Weekly schedule, `ci` commit prefix (matches repo convention), `dependencies`/`github-actions` labels, up to 10 open PRs.

Scope is intentionally limited to GitHub Actions (not the `mix` ecosystem). Once merged to `main`, Dependabot will start opening PRs to bump outdated workflow actions (`actions/checkout@v3`, `actions/cache@v3`, `erlef/setup-beam@v1`, `reviewdog/action-setup@v1`, `actions/github-script@v7`).

## Verification

- YAML syntax validated locally (parses clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)