### PR TITLE
chore: ignore macOS .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ node_modules/
 /node_modules/
 
 *.~undo-tree~
+
+# macOS Finder metadata
+.DS_Store


### PR DESCRIPTION
## Summary
- Add `.DS_Store` to `.gitignore` so macOS Finder metadata stays out of the working tree status.

## Why
Two untracked `.DS_Store` files were appearing in `git status`. Ignoring them keeps the status clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)